### PR TITLE
loader: don't panic on ./example/util

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,5 @@ require (
 	golang.org/x/net v0.0.0-20181023162649-9b4f9f5ad519 // indirect
 	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f // indirect
 	golang.org/x/tools v0.0.0-20181026183834-f60e5f99f081
+	google.golang.org/genproto v0.0.0-20181029155118-b69ba1387ce2
 )

--- a/go.sum
+++ b/go.sum
@@ -8,3 +8,5 @@ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f h1:wMNYb4v58l5UBM7MYRLPG6Zh
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/tools v0.0.0-20181026183834-f60e5f99f081 h1:QJP9sxq2/KbTxFnGduVryxJOt6r/UVGyom3tLaqu7tc=
 golang.org/x/tools v0.0.0-20181026183834-f60e5f99f081/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+google.golang.org/genproto v0.0.0-20181029155118-b69ba1387ce2 h1:67iHsV9djwGdZpdZNbLuQj6FOzCaZe3w+vhLjn5AcFA=
+google.golang.org/genproto v0.0.0-20181029155118-b69ba1387ce2/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=


### PR DESCRIPTION
In master, trying to generate the example seems to panic:

	$ go install
	$ gunk ./examples/util
	panic: unknown or mismatched type: type: loader.httpRule, wire type: varint

The underlying reason is that we rolled our own type and definition for
Google's http protobuf extension. That worked before, but has broken at
some point in the past few months, likely during a protobuf or protobuf
generator release.

To fix the issue and ensure this doesn't happen again, simply use the
protobuf-generated code from google.golang.org to set up their
extensions. This is simpler, and should work as long as we update all
protobuf deps in sync.

Running gunk on the example works on my machine now.