### PR TITLE
CI: fix build via modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,18 @@
-language: go
-go:
-  - 1.10.x
-  - 1.11.x
-  - tip
 sudo: false
+
+language: go
+
+go:
+  - 1.11.x
+
+env:
+  - GO111MODULE=on
+
 addons:
   apt:
     packages:
       - unzip
+
 before_install:
   - mkdir -p $PWD/protoc /tmp/protobuf
   - wget -O $PWD/protoc/protoc https://repo1.maven.org/maven2/com/google/protobuf/protoc/3.6.1/protoc-3.6.1-linux-x86_64.exe
@@ -15,7 +20,9 @@ before_install:
   - unzip -qq /tmp/protobuf/protobuf.jar -d /tmp/protobuf && mv /tmp/protobuf/google $PWD
   - chmod +x $PWD/protoc/protoc
   - export PATH=$PWD/protoc/:$PATH
+
 install: true
+
 script:
-  - go install ./vendor/github.com/golang/protobuf/protoc-gen-go
-  - go test -v -short ./...
+  - go install github.com/golang/protobuf/protoc-gen-go
+  - go test -v ./...

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	desc "github.com/golang/protobuf/protoc-gen-go/descriptor"
-	_ "github.com/golang/protobuf/protoc-gen-go/grpc"
 	plugin "github.com/golang/protobuf/protoc-gen-go/plugin"
 	"google.golang.org/genproto/googleapis/api/annotations"
 )

--- a/tools.go
+++ b/tools.go
@@ -1,0 +1,8 @@
+// +build tools
+
+package tools
+
+import (
+	// required by the tests
+	_ "github.com/golang/protobuf/protoc-gen-go"
+)


### PR DESCRIPTION
Start using the full power of modules on CI. To do that, we must drop Go
1.10, as it only has minimal support for them.

While at it, drop tip too, as it's a moving target and not very useful
to enforce on CI. I develop on tip, so if an upcoming Go release were to
require changes in Gunk, we'd notice anyway.