### PR TITLE
loader: make protoc-gen-grpc-gateway deterministic

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -207,16 +207,23 @@ func (l *Loader) generatePluginGrpcGateway(req plugin.CodeGeneratorRequest) erro
 }
 
 func (l *Loader) requestForPkg(path string) *plugin.CodeGeneratorRequest {
-	// For deterministic output, as the first file in each package
-	// gets an extra package godoc.
 	req := &plugin.CodeGeneratorRequest{}
 	for file := range l.toGen[path] {
 		req.FileToGenerate = append(req.FileToGenerate, file)
 	}
-	sort.Strings(req.FileToGenerate)
 	for _, pfile := range l.allProto {
 		req.ProtoFile = append(req.ProtoFile, pfile)
 	}
+
+	// Sort all the files by name to get deterministic output. For example,
+	// the first file in each package gets an extra package godoc from
+	// protoc-gen-go. And protoc-gen-grpc-gateway cares about the order of
+	// the ProtoFile list.
+	sort.Strings(req.FileToGenerate)
+	sort.Slice(req.ProtoFile, func(i, j int) bool {
+		return *req.ProtoFile[i].Name < *req.ProtoFile[j].Name
+	})
+
 	return req
 }
 

--- a/testdata/echo.pb.gw.go
+++ b/testdata/echo.pb.gw.go
@@ -21,7 +21,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/status"
-	"testdata.tld/util/imported"
+	imported_0 "testdata.tld/util/imported"
 )
 
 var _ codes.Code
@@ -31,7 +31,7 @@ var _ = runtime.String
 var _ = utilities.NewDoubleArray
 
 func request_Util_Echo_0(ctx context.Context, marshaler runtime.Marshaler, client UtilClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq imported.Message
+	var protoReq imported_0.Message
 	var metadata runtime.ServerMetadata
 
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {


### PR DESCRIPTION
It was unstable since the order of the ProtoFile list was not
deterministic. Sort them by filename to stop that from happening.

After this fix, a hundred test runs passed on my laptop, when it was
hard to get past 10 consecutive test runs before.

Fixes #24.