### PR TITLE
loader: preparation for custom proto package names

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -9,9 +9,8 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/rogpeppe/go-internal/testscript"
-
 	"github.com/gunk/gunk/loader"
+	"github.com/rogpeppe/go-internal/testscript"
 )
 
 var write = flag.Bool("w", false, "overwrite testdata output files")

--- a/testdata/generate/echo.gunk
+++ b/testdata/generate/echo.gunk
@@ -1,5 +1,5 @@
 // package util contains a simple Echo service.
-package util
+package util // proto "testdata.v1.util"
 
 import (
 	"time"


### PR DESCRIPTION
Initially I wanted to get this done independently in a single commit,
but it turns out to be trickier. We need to know all protobuf package
names upfront, so that we can write fully qualified names properly.

I had another PR in the works that revamped package loading and
introduced the notion of a "gunk package", so that should be merged to
help with this task. So it's best to merge this piece first, and then
finish off the feature once the loading refactor is merged.

Updates #44.