### PR TITLE
loader: improve loading gunk packages

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -18,21 +18,23 @@ var write = flag.Bool("w", false, "overwrite testdata output files")
 func TestMain(m *testing.M) {
 	flag.Parse()
 
-	// Don't put the binaries in a temporary directory to delete, as that
-	// means we have to re-link them every single time. That's quite
-	// expensive, at around half a second per 'go test' invocation.
-	binDir, err := filepath.Abs(".bin")
-	if err != nil {
-		panic(err)
-	}
-	os.Setenv("GOBIN", binDir)
-	os.Setenv("PATH", binDir+string(filepath.ListSeparator)+os.Getenv("PATH"))
-	cmd := exec.Command("go", "install", "-ldflags=-w -s",
-		"github.com/golang/protobuf/protoc-gen-go",
-		"github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway",
-	)
-	if err := cmd.Run(); err != nil {
-		panic(err)
+	if os.Getenv("TESTSCRIPT_COMMAND") == "" {
+		// Don't put the binaries in a temporary directory to delete, as that
+		// means we have to re-link them every single time. That's quite
+		// expensive, at around half a second per 'go test' invocation.
+		binDir, err := filepath.Abs(".bin")
+		if err != nil {
+			panic(err)
+		}
+		os.Setenv("GOBIN", binDir)
+		os.Setenv("PATH", binDir+string(filepath.ListSeparator)+os.Getenv("PATH"))
+		cmd := exec.Command("go", "install", "-ldflags=-w -s",
+			"github.com/golang/protobuf/protoc-gen-go",
+			"github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway",
+		)
+		if err := cmd.Run(); err != nil {
+			panic(err)
+		}
 	}
 
 	os.Exit(testscript.RunMain(m, map[string]func() int{

--- a/testdata/scripts/empty.txt
+++ b/testdata/scripts/empty.txt
@@ -1,10 +1,23 @@
-# empty Gunk package
 env HOME=$WORK/home
-! exec gunk .
+
+# generating an empty Gunk package should fail
+! gunk .
+stderr 'no Gunk packages to generate'
+
+# generating many empty Gunk package should fail
+! gunk . ./p2
+stderr 'no Gunk packages to generate'
+
+# generating packages if some are empty should be OK
+gunk ./...
 
 -- go.mod --
 module testdata.tld/util
 -- doc.go --
-package util
-
-// make this directory a Go package
+package util // make this directory a Go package
+-- p2/doc.go --
+package p2 // make this directory a Go package
+-- p3/doc.go --
+package p3 // make this directory a Go package
+-- p3/echo.gunk --
+package p3


### PR DESCRIPTION
Add a gunkPackage structure, which is a wrapper over packages.Package
which adds GunkFiles. This lets us reason about loading Gunk packages
better, instead of loading Gunk files in an ad-hoc manner.

Now, all the information about what gunk files to translate is known
upfront, before any translation happens.

This lets us handle certain edge cases better, such as being given Go
packages with zero gunk files. Added test cases for those.