### PR TITLE
format: add first version of 'gunk fmt'

### DIFF
--- a/format/format.go
+++ b/format/format.go
@@ -1,0 +1,50 @@
+package format
+
+import (
+	"bytes"
+	"fmt"
+	"go/ast"
+	"go/format"
+	"go/token"
+	"io/ioutil"
+
+	"github.com/gunk/gunk/loader"
+)
+
+// Format rewrites Gunk files to be canonically formatted.
+func Format(dir string, patterns ...string) error {
+	fset := token.NewFileSet()
+	pkgs, err := loader.Load(dir, fset, patterns...)
+	if err != nil {
+		return err
+	}
+	if len(pkgs) == 0 {
+		return fmt.Errorf("no Gunk packages to format")
+	}
+	for _, pkg := range pkgs {
+		for i, file := range pkg.GunkSyntax {
+			path := pkg.GunkFiles[i]
+			if err := formatFile(fset, path, file); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func formatFile(fset *token.FileSet, path string, file *ast.File) error {
+	orig, err := ioutil.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	var buf bytes.Buffer
+	if err := format.Node(&buf, fset, file); err != nil {
+		return err
+	}
+	got := buf.Bytes()
+	if bytes.Equal(orig, got) {
+		// already formatted; nothing to do
+		return nil
+	}
+	return ioutil.WriteFile(path, got, 0666)
+}

--- a/main.go
+++ b/main.go
@@ -7,18 +7,22 @@ import (
 	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/gunk/gunk/convert"
+	"github.com/gunk/gunk/format"
 	"github.com/gunk/gunk/generate"
 )
 
 var (
 	app = kingpin.New("gunk", "Gunk Unified N-terface Kompiler command-line tool.")
 
-	gen         = app.Command("generate", "Generate code.")
+	gen         = app.Command("generate", "Generate code from Gunk packages.")
 	genPatterns = gen.Arg("patterns", "patterns of Gunk packages").Strings()
 
 	conv                  = app.Command("convert", "Convert Proto file to Gunk file.")
 	convProtoFile         = conv.Arg("file", "Proto file to convert to Gunk").String()
 	convOverwriteGunkFile = conv.Flag("overwrite", "overwrite the converted Gunk file if it exists.").Bool()
+
+	frmt         = app.Command("format", "Format Gunk code.")
+	frmtPatterns = frmt.Arg("patterns", "patterns of Gunk packages").Strings()
 )
 
 func main() {
@@ -26,19 +30,18 @@ func main() {
 }
 
 func main1() int {
+	var err error
 	switch kingpin.MustParse(app.Parse(os.Args[1:])) {
-	// Register generate command.
 	case gen.FullCommand():
-		if err := generate.Generate("", *genPatterns...); err != nil {
-			fmt.Fprintf(os.Stderr, "error: %v\n", err)
-			return 1
-		}
+		err = generate.Generate("", *genPatterns...)
 	case conv.FullCommand():
-		if err := convert.Convert(*convProtoFile, *convOverwriteGunkFile); err != nil {
-			fmt.Fprintf(os.Stderr, "error: %v\n", err)
-			return 1
-		}
+		err = convert.Convert(*convProtoFile, *convOverwriteGunkFile)
+	case frmt.FullCommand():
+		err = format.Format("", *frmtPatterns...)
 	}
-
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
 	return 0
 }

--- a/testdata/scripts/fmt.txt
+++ b/testdata/scripts/fmt.txt
@@ -1,0 +1,29 @@
+env HOME=$WORK/home
+
+# formatting an empty Gunk package should fail
+! gunk format ./empty
+stderr 'no Gunk packages to format'
+
+# formatting a normal package and checking the result
+gunk format .
+cmp echo.gunk echo.gunk.golden
+
+-- go.mod --
+module testdata.tld/util
+-- doc.go --
+package util // make this directory a Go package
+-- empty/doc.go --
+package empty // make this directory a Go package
+
+-- echo.gunk --
+package util   // proto "testdata.v1.util"
+
+type Request struct {
+Status Status    `pb:"1" json:"status"`
+}
+-- echo.gunk.golden --
+package util // proto "testdata.v1.util"
+
+type Request struct {
+	Status Status `pb:"1" json:"status"`
+}


### PR DESCRIPTION
For now, all we do iss format the Go syntax. Formatting of our extra
Gunk additions, such as the +gunk comment expressions, will come later.

Updates #37.