### PR TITLE
generate: simplify handling of doc strings

### DIFF
--- a/generate/proto.go
+++ b/generate/proto.go
@@ -19,13 +19,6 @@ const (
 	serviceMethodPath = 2 // ServiceDescriptorProto.Method
 )
 
-// namePrefix returns a func which prefixes the supplied name.
-func namePrefix(name string) func(string) string {
-	return func(text string) string {
-		return name + "_" + text
-	}
-}
-
 // splitGunkTag splits a '+gunk' tag.
 func splitGunkTag(text string) (doc, tag string) {
 	lines := strings.Split(text, "\n")


### PR DESCRIPTION
We were being too clever with the transform functions. Doing it the
trivial way is actually much simpler.

Most importantly, this will let us have more complex logic to extract
the +gunk tags, which we need for #35.