### PR TITLE
all: remove stutter from subcommand funcs

### DIFF
--- a/convert/convert.go
+++ b/convert/convert.go
@@ -34,9 +34,9 @@ type builder struct {
 	imports []*proto.Import
 }
 
-// Convert will convert a proto file to a gunk file,
-// saving the file in the same folder as the proto file.
-func Convert(path string, overwrite bool) error {
+// Run converts a proto file to a gunk file, saving the file in the same folder
+// as the proto file.
+func Run(path string, overwrite bool) error {
 	if filepath.Ext(path) != ".proto" {
 		return fmt.Errorf("convert requires a .proto file")
 	}

--- a/format/format.go
+++ b/format/format.go
@@ -11,10 +11,10 @@ import (
 	"github.com/gunk/gunk/loader"
 )
 
-// Format rewrites Gunk files to be canonically formatted.
-func Format(dir string, patterns ...string) error {
+// Run formats Gunk files to be canonically formatted.
+func Run(dir string, args ...string) error {
 	fset := token.NewFileSet()
-	pkgs, err := loader.Load(dir, fset, patterns...)
+	pkgs, err := loader.Load(dir, fset, args...)
 	if err != nil {
 		return err
 	}

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -27,9 +27,9 @@ import (
 	"github.com/gunk/gunk/loader"
 )
 
-// Generate runs protobuf generators on the specified Gunk packages, writing the
-// output files in the same directories.
-func Generate(dir string, patterns ...string) error {
+// Run generates the specified Gunk packages via protobuf generators, writing
+// the output files in the same directories.
+func Run(dir string, args ...string) error {
 	cfg, err := config.Load(dir)
 	if err != nil {
 		return fmt.Errorf("unable to load gunkconfig: %v", err)
@@ -53,7 +53,7 @@ func Generate(dir string, patterns ...string) error {
 	}
 	g.tconfig.Importer = g
 
-	pkgs, err := loader.Load(g.dir, g.fset, patterns...)
+	pkgs, err := loader.Load(g.dir, g.fset, args...)
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -33,11 +33,11 @@ func main1() int {
 	var err error
 	switch kingpin.MustParse(app.Parse(os.Args[1:])) {
 	case gen.FullCommand():
-		err = generate.Generate("", *genPatterns...)
+		err = generate.Run("", *genPatterns...)
 	case conv.FullCommand():
-		err = convert.Convert(*convProtoFile, *convOverwriteGunkFile)
+		err = convert.Run(*convProtoFile, *convOverwriteGunkFile)
 	case frmt.FullCommand():
-		err = format.Format("", *frmtPatterns...)
+		err = format.Run("", *frmtPatterns...)
 	}
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)

--- a/main_test.go
+++ b/main_test.go
@@ -56,7 +56,7 @@ func TestGenerate(t *testing.T) {
 		os.Remove(path)
 	}
 
-	if err := generate.Generate(dir, pkgs...); err != nil {
+	if err := generate.Run(dir, pkgs...); err != nil {
 		t.Fatal(err)
 	}
 	if *write {


### PR DESCRIPTION
generate.Run is better than generate.Generate.