### PR TITLE
test: don't use os.Link to place files in tests

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -120,9 +120,16 @@ func TestGenerateError(t *testing.T) {
 	testscript.Run(t, testscript.Params{
 		Dir: filepath.Join("testdata", "scripts"),
 		Setup: func(env *testscript.Env) error {
-			oldName := filepath.Join("testdata/generate", ".gunkconfig")
+			// Use a full copy instead of a hard link or a symbolic
+			// link, as those can cause issues if /tmp is a separate
+			// filesystem device.
+			oldName := filepath.Join("testdata", "generate", ".gunkconfig")
 			newName := filepath.Join(env.WorkDir, ".gunkconfig")
-			return os.Link(oldName, newName)
+			bs, err := ioutil.ReadFile(oldName)
+			if err != nil {
+				return err
+			}
+			return ioutil.WriteFile(newName, bs, 0777)
 		},
 	})
 }


### PR DESCRIPTION
This can cause issues in a system like mine, where /tmp is a ramdisk:

	link [...]/.gunkconfig /tmp/[...]: invalid cross-device link