### PR TITLE
generate, mod: copy pointer values before updating them

### DIFF
--- a/examples/util/.gunkconfig
+++ b/examples/util/.gunkconfig
@@ -1,3 +1,9 @@
 [generate]
 command=protoc-gen-grpc-gateway
 logtostderr=true
+
+[generate]
+protoc=python
+
+[generate]
+protoc=js

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -152,8 +152,17 @@ func (g *Generator) generateProtoc(req plugin.CodeGeneratorRequest, gen config.G
 	// a formatted list of what is in req.FileToGenerate.
 	protoFilenames := []string{}
 
+	// Make copies of the req.ProtoFile so we don't accidentally change
+	// the values of the pointers which will affect all other protoc
+	// generator runs.
+	protoFiles := make([]*desc.FileDescriptorProto, len(req.ProtoFile))
+	for i, pf := range req.ProtoFile {
+		tmpPf := *pf
+		protoFiles[i] = &tmpPf
+	}
+
 	fds := desc.FileDescriptorSet{
-		File: req.ProtoFile,
+		File: protoFiles,
 	}
 	// Determine the files that protoc will be generating and
 	// remove the package directory path and change .gunk to .proto.

--- a/go.mod
+++ b/go.mod
@@ -21,3 +21,5 @@ require (
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/yaml.v2 v2.2.1 // indirect
 )
+
+replace github.com/knq/ini => github.com/vishen/ini v0.0.0-20181114105943-e8b73a8b85fb

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,10 @@ github.com/rogpeppe/go-internal v1.0.0 h1:o4VLZ5jqHE+HahLT6drNtSGTrrUA3wPBmtpgqt
 github.com/rogpeppe/go-internal v1.0.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/vishen/ini v0.0.0-20181114075600-0e4d8f27e48e h1:+8tep4Yegg7IyaYGnreK1NxnahaMgQ0K2aDWBui09No=
+github.com/vishen/ini v0.0.0-20181114075600-0e4d8f27e48e/go.mod h1:kWZM2Rp5R3eP4q91Xms9JPMXuH7+yQrfTd3ZVzhxTUE=
+github.com/vishen/ini v0.0.0-20181114105943-e8b73a8b85fb h1:GB1X/gZb7wQgJAsH7VifrmWilAOjvQM5DMXe6Er+mEw=
+github.com/vishen/ini v0.0.0-20181114105943-e8b73a8b85fb/go.mod h1:kWZM2Rp5R3eP4q91Xms9JPMXuH7+yQrfTd3ZVzhxTUE=
 golang.org/x/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181029044818-c44066c5c816 h1:mVFkLpejdFLXVUv9E42f3XJVfMdqd0IVLVIVLjZWn5o=


### PR DESCRIPTION
In each 'generateProtoc' run we modify the protofile name, however, this
was a pointer, and was changing the value for all runs of
'generateProtoc' and 'generatePlugin'. Make a dumb copy of the protofile
before we use it.

Updated the ini parser to a forked version that handles multiple
section names, and getting keys from the different sections, correctly.

I have created a PR upstream for [ini](https://github.com/knq/ini/pull/1), until then we can use my fork of the ini parser.