### PR TITLE
config: use params key in section for generator params

### DIFF
--- a/examples/util/.gunkconfig
+++ b/examples/util/.gunkconfig
@@ -1,9 +1,10 @@
 [generate]
 command=protoc-gen-grpc-gateway
-logtostderr=true
+params=logtostderr=true
 
 [generate]
 protoc=python
 
 [generate]
 protoc=js
+paramas=import_style=commonjs,binary

--- a/testdata/generate/.gunkconfig
+++ b/testdata/generate/.gunkconfig
@@ -1,3 +1,3 @@
 [generate]
 command=protoc-gen-grpc-gateway
-logtostderr=true
+params=logtostderr=true


### PR DESCRIPTION
Have a specific key for generator params in gunkconfig. This is required
because some generators want the params in arbitrary formats, and the ini
section format of key values won't make sense for all generators.