### PR TITLE
format: also reformat +gunk tags in comments

### DIFF
--- a/format/format.go
+++ b/format/format.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"go/ast"
 	"go/format"
+	"go/printer"
 	"go/token"
 	"io/ioutil"
+	"strings"
 
 	"github.com/gunk/gunk/loader"
 )
@@ -32,11 +34,51 @@ func Run(dir string, args ...string) error {
 	return nil
 }
 
-func formatFile(fset *token.FileSet, path string, file *ast.File) error {
+func formatFile(fset *token.FileSet, path string, file *ast.File) (formatErr error) {
 	orig, err := ioutil.ReadFile(path)
 	if err != nil {
 		return err
 	}
+
+	// Use custom panic values to report errors from the inspect func,
+	// since that's the easiest way to immediately halt the process and
+	// return the error.
+	type inspectError struct{ err error }
+	defer func() {
+		if r := recover(); r != nil {
+			if ierr, ok := r.(inspectError); ok {
+				formatErr = ierr.err
+			} else {
+				panic(r)
+			}
+		}
+	}()
+	ast.Inspect(file, func(node ast.Node) bool {
+		group, ok := node.(*ast.CommentGroup)
+		if !ok {
+			return true
+		}
+		doc, tag, err := loader.SplitGunkTag(fset, group)
+		if err != nil {
+			panic(inspectError{err})
+		}
+		if tag == nil {
+			// no gunk tag
+			return true
+		}
+		var buf bytes.Buffer
+
+		// Print with space indentation, since all comment lines begin
+		// with "// " and we don't want to mix spaces and tabs.
+		config := printer.Config{Mode: printer.UseSpaces, Tabwidth: 8}
+		if err := config.Fprint(&buf, fset, tag); err != nil {
+			panic(inspectError{err})
+		}
+		text := doc + "\n\n+gunk " + buf.String()
+		*group = *commentFromText(group, text)
+		return true
+	})
+
 	var buf bytes.Buffer
 	if err := format.Node(&buf, fset, file); err != nil {
 		return err
@@ -47,4 +89,24 @@ func formatFile(fset *token.FileSet, path string, file *ast.File) error {
 		return nil
 	}
 	return ioutil.WriteFile(path, got, 0666)
+}
+
+func commentFromText(orig ast.Node, text string) *ast.CommentGroup {
+	group := &ast.CommentGroup{}
+	lines := strings.Split(text, "\n")
+	for i, line := range lines {
+		comment := &ast.Comment{Text: "// " + line}
+
+		// Ensure that group.Pos() and group.End() stay on the same
+		// lines, to ensure that printing doesn't move the comment
+		// around or introduce newlines.
+		switch i {
+		case 0:
+			comment.Slash = orig.Pos()
+		case len(lines) - 1:
+			comment.Slash = orig.End()
+		}
+		group.List = append(group.List, comment)
+	}
+	return group
 }

--- a/testdata/scripts/fmt.txt
+++ b/testdata/scripts/fmt.txt
@@ -14,16 +14,40 @@ module testdata.tld/util
 package util // make this directory a Go package
 -- empty/doc.go --
 package empty // make this directory a Go package
-
 -- echo.gunk --
 package util   // proto "testdata.v1.util"
 
-type Request struct {
-Status Status    `pb:"1" json:"status"`
+type Message struct {
+Text string    `pb:"1" json:"text"`
 }
+
+// Util is a utility service.
+type Util interface {
+// Echo echoes a message.
+//
+// +gunk http.Match{
+// Method: "POST",
+// Path: "/v1/echo",
+// Body: "*",
+// }
+Echo(Message) Message
+}
+
 -- echo.gunk.golden --
 package util // proto "testdata.v1.util"
 
-type Request struct {
-	Status Status `pb:"1" json:"status"`
+type Message struct {
+	Text string `pb:"1" json:"text"`
+}
+
+// Util is a utility service.
+type Util interface {
+	// Echo echoes a message.
+	//
+	// +gunk http.Match{
+	//         Method: "POST",
+	//         Path:   "/v1/echo",
+	//         Body:   "*",
+	// }
+	Echo(Message) Message
 }


### PR DESCRIPTION
This is a bit tricky, since we need to extract the tag, parse it, print
it, and put it back in the comment without messing up the relative
positions.

Fixes #37.