### PR TITLE
config,generate: out path is configurable in gunkconfig

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -21,6 +21,7 @@ type Generator struct {
 	Command   string
 	Params    []KeyValue
 	ConfigDir string
+	Out       string
 }
 
 func (g Generator) IsProtoc() bool {
@@ -40,11 +41,19 @@ func (g Generator) ParamString() string {
 }
 
 func (g Generator) ParamStringWithOut() string {
+	outPath := g.OutPath()
 	params := g.ParamString()
 	if params == "" {
-		return g.ConfigDir
+		return outPath
 	}
-	return params + ":" + g.ConfigDir
+	return params + ":" + outPath
+}
+
+func (g Generator) OutPath() string {
+	if g.Out != "" {
+		return g.Out
+	}
+	return g.ConfigDir
 }
 
 type Config struct {
@@ -90,7 +99,6 @@ func Load(dir string) (*Config, error) {
 		cfg.Dir = startDir
 		// Patch in the directory of where to output the generated
 		// files.
-		// TODO(vishen): Make this configurable
 		for i := range cfg.Generators {
 			cfg.Generators[i].ConfigDir = startDir
 		}
@@ -156,6 +164,8 @@ func handleGenerate(section *parser.Section) (*Generator, error) {
 				return nil, fmt.Errorf("only one 'command' or 'protoc' allowed")
 			}
 			gen.ProtocGen = v
+		case "out":
+			gen.Out = v
 		default:
 			gen.Params = append(gen.Params, KeyValue{k, v})
 		}

--- a/examples/util/.gunkconfig
+++ b/examples/util/.gunkconfig
@@ -1,9 +1,17 @@
 [generate]
+out=v1/
+command=protoc-gen-go
+plugins=grpc
+
+[generate]
+out=v1/
 command=protoc-gen-grpc-gateway
 logtostderr=true
 
 [generate]
+out=v1/
 protoc=python
 
 [generate]
+out=v1/
 protoc=js

--- a/testdata/generate/.gunkconfig
+++ b/testdata/generate/.gunkconfig
@@ -1,3 +1,7 @@
 [generate]
+command=protoc-gen-go
+plugins=grpc
+
+[generate]
 command=protoc-gen-grpc-gateway
 logtostderr=true


### PR DESCRIPTION
If an 'out' key is specified in a gunkconfig generate section, that will
be used as the directory to output the generated files. If the key
doesn't exist, we default to outputting the generated file to where the
'*.gunk' file was found (the current behaviour).

Stop running 'protoc-gen-go' by default. This didn't work with having
configurable out paths, because each out path is seperate for each
section, and there is no good way to set the out path for the Go
generator. Instead update the .gunkconfig to run the Go generator.