### PR TITLE
generate: return error from protoc generator plugins

### DIFF
--- a/generate/generate.go
+++ b/generate/generate.go
@@ -237,6 +237,9 @@ func (g *Generator) generatePlugin(req plugin.CodeGeneratorRequest, gen config.G
 	if err := proto.Unmarshal(out, &resp); err != nil {
 		return err
 	}
+	if rerr := resp.GetError(); rerr != "" {
+		return fmt.Errorf("error from generator %s: %s", gen.Command, rerr)
+	}
 	for _, rf := range resp.File {
 		// Turn the relative package file path to the absolute
 		// on-disk file path.


### PR DESCRIPTION
If a 'protoc-gen-*' returns an error, we will check for the error and
return it to the user.