### PR TITLE
config,generate: look for gunkconfig in each gunk package

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ the Go programming language:
 Working with the `gunk` command line tool should be instantly recognizable to
 experienced Go developers:
 
-	cd ./examples/util
-	gunk generate .
+	gunk generate ./examples/util
 
 ## Overview
 

--- a/config/config.go
+++ b/config/config.go
@@ -48,8 +48,12 @@ func (g Generator) ParamString() string {
 	return strings.Join(params, ",")
 }
 
-func (g Generator) ParamStringWithOut() string {
-	outPath := g.OutPath()
+// ParamStringWithOut will return the generator paramaters formatted
+// for protoc, including where protoc should output the generated files.
+// It will use 'packageDir' if no 'out' key was set in the config.
+func (g Generator) ParamStringWithOut(packageDir string) string {
+	// If no out path was specified, use the package directory.
+	outPath := g.OutPath(packageDir)
 	params := g.ParamString()
 	if params == "" {
 		return outPath
@@ -57,11 +61,16 @@ func (g Generator) ParamStringWithOut() string {
 	return params + ":" + outPath
 }
 
-func (g Generator) OutPath() string {
-	if g.Out != "" {
+// Determine an out path for a generator to write generated files to.
+// It will use 'packageDir' if no 'out' key was set in the config.
+func (g Generator) OutPath(packageDir string) string {
+	if g.Out == "" {
+		return packageDir
+	}
+	if filepath.IsAbs(g.Out) {
 		return g.Out
 	}
-	return g.ConfigDir
+	return filepath.Join(g.ConfigDir, g.Out)
 }
 
 type Config struct {

--- a/examples/util/v1/.gitignore
+++ b/examples/util/v1/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/testdata/scripts/config.txt
+++ b/testdata/scripts/config.txt
@@ -1,0 +1,33 @@
+env HOME=$WORK/home
+
+# Gunk generate with out specified in config
+gunk generate ./gunk
+
+# Check that that files were generated in the correct folder
+exists gunk/all.pb.go gunk/all_pb2.py
+
+-- go.mod --
+module testdata.tld/util
+
+-- gunk/.gunkconfig --
+[generate]
+command=protoc-gen-go
+plugins=grpc
+
+[generate]
+protoc=python
+
+-- gunk/doc.go --
+package util // make this directory a Go package
+
+-- gunk/util.gunk --
+package util
+
+type Message struct {
+	Msg string `pb:"1"`
+}
+
+type Util interface {
+	// Echo echoes a message.
+	Echo(Message) Message
+}

--- a/testdata/scripts/config_default.txt
+++ b/testdata/scripts/config_default.txt
@@ -1,0 +1,35 @@
+env HOME=$WORK/home
+
+# Gunk generate with out specified in config
+gunk generate ./gunk
+
+# Check that that files were generated in the correct folder
+exists gunk/all.pb.go gunk/all.pb.gw.go
+
+-- go.mod --
+module testdata.tld/util
+
+-- gunk/doc.go --
+package util // make this directory a Go package
+
+-- gunk/util.gunk --
+package util
+
+import (
+	"github.com/gunk/opt/http"
+)
+
+type Message struct {
+	Msg string `pb:"1"`
+}
+
+type Util interface {
+	// Echo echoes a message.
+	//
+	// +gunk http.Match{
+	//         Method: "POST",
+	//         Path:   "/v1/echo",
+	//         Body:   "*",
+	// }
+	Echo(Message) Message
+}

--- a/testdata/scripts/config_parent.txt
+++ b/testdata/scripts/config_parent.txt
@@ -1,0 +1,33 @@
+env HOME=$WORK/home
+
+# Gunk generate with out specified in config
+gunk generate ./gunk
+
+# Check that that files were generated in the correct folder
+exists gunk/all.pb.go gunk/all_pb2.py
+
+-- go.mod --
+module testdata.tld/util
+
+-- .gunkconfig --
+[generate]
+command=protoc-gen-go
+plugins=grpc
+
+[generate]
+protoc=python
+
+-- gunk/doc.go --
+package util // make this directory a Go package
+
+-- gunk/util.gunk --
+package util
+
+type Message struct {
+	Msg string `pb:"1"`
+}
+
+type Util interface {
+	// Echo echoes a message.
+	Echo(Message) Message
+}

--- a/testdata/scripts/config_with_out.txt
+++ b/testdata/scripts/config_with_out.txt
@@ -1,0 +1,40 @@
+env HOME=$WORK/home
+
+# Files should be generated here
+mkdir gunk/v1
+
+# Gunk generate with out specified in config
+gunk generate ./gunk
+
+# Check that that files were generated in the correct folder
+exists gunk/v1/all.pb.go gunk/v1/all_pb2.py
+
+! exists gunk/all.pb.go gunk/all_pb2.py
+
+-- go.mod --
+module testdata.tld/util
+
+-- gunk/.gunkconfig --
+[generate]
+out=v1/
+command=protoc-gen-go
+plugins=grpc
+
+[generate]
+out=v1/
+protoc=python
+
+-- gunk/doc.go --
+package util // make this directory a Go package
+
+-- gunk/util.gunk --
+package util
+
+type Message struct {
+	Msg string `pb:"1"`
+}
+
+type Util interface {
+	// Echo echoes a message.
+	Echo(Message) Message
+}


### PR DESCRIPTION
Look for a .gunkconfig in each gunk package, if one isn't found then
look in each parent to see if one exists. The path for generators to
output generated files will be the following:

    - Next to the *.gunk files, if no 'out' key specified (the default)
    - Wherever the 'out' key specifies. If the path is absolute, we use
    that path. If it isn't absolute, then we join the 'out' with the
    directory containing the .gunkconfig

Added 'examples/util/v1' which is where the files should be generated.

Closes #82