### PR TITLE
generate: avoid confusing error if protoc errors

### DIFF
--- a/generate/generate.go
+++ b/generate/generate.go
@@ -850,7 +850,7 @@ func (g *Generator) loadProtoDeps() error {
 
 	files, err := loader.LoadProto(list...)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	for _, pfile := range files {

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -178,7 +178,7 @@ syntax = "proto3";
 	out, err := cmd.Output()
 	if err != nil {
 		if e, ok := err.(*exec.ExitError); ok {
-			return nil, fmt.Errorf("%s", e.Stderr)
+			return nil, fmt.Errorf("protoc %s: %s", e, e.Stderr)
 		}
 		return nil, err
 	}

--- a/testdata/scripts/envs.txt
+++ b/testdata/scripts/envs.txt
@@ -1,0 +1,30 @@
+env HOME=$WORK/home
+
+# protoc can't be run correctly to resolve proto imports
+env PATH=$WORK/bin:$PATH
+exec chmod a+x bin/protoc
+
+# we should stop before any generators are run
+! gunk generate .
+! stdout .
+stderr 'exit status'
+stderr 'fatal failure'
+! stderr 'error executing protoc-gen'
+! stderr panicc
+
+-- bin/protoc --
+#!/bin/sh
+
+echo fatal failure >&2
+
+exit 1
+-- go.mod --
+module testdata.tld/util
+-- doc.go --
+package util // make this directory a Go package
+-- echo.gunk --
+package util // proto "testdata.v1.util"
+
+type Util interface {
+	Echo() // use google.protobuf.Empty, which requires protoc
+}


### PR DESCRIPTION
We were skipping the error from loading proto dependencies, which could
lead to confusing errors down the line or even panics.

Add a test too. While at it, improve that error's context.

Fixes #85.