### PR TITLE
generate: error on array function parameters

### DIFF
--- a/generate/generate.go
+++ b/generate/generate.go
@@ -644,9 +644,12 @@ func (g *Generator) convertParameter(tuple *types.Tuple) (*string, error) {
 		return nil, fmt.Errorf("multiple parameters are not supported")
 	}
 	param := tuple.At(0).Type()
-	_, _, tname := g.convertType(param)
+	_, label, tname := g.convertType(param)
 	if tname == "" {
 		return nil, fmt.Errorf("unsupported parameter type: %v", param)
+	}
+	if label == desc.FieldDescriptorProto_LABEL_REPEATED {
+		return nil, fmt.Errorf("parameter type should not be repeated")
 	}
 	return &tname, nil
 }

--- a/testdata/scripts/repeated_function_param.txt
+++ b/testdata/scripts/repeated_function_param.txt
@@ -1,0 +1,36 @@
+env HOME=$WORK/home
+
+! gunk generate ./p1
+stderr 'error: parameter type should not be repeated'
+
+! gunk generate ./p2
+stderr 'error: parameter type should not be repeated'
+
+-- go.mod --
+module testdata.tld/util
+-- p1/doc.go --
+package util // make this directory a Go package
+-- p1/p1.gunk --
+package util
+
+type Message struct {
+	Msg string `pb:"1"`
+}
+
+type Util interface {
+	// Echo echoes a message.
+	Echo(Message) []Message
+}
+-- p2/doc.go --
+package util // make this directory a Go package
+-- p2/p2.gunk --
+package util
+
+type Message struct {
+	Msg string `pb:"1"`
+}
+
+type Util interface {
+	// Echo echoes a message.
+	Echo([]Message) Message
+}


### PR DESCRIPTION
Proto doesn't allow you to have repeated function parameters. However,
it is easy to forget when Go and other languages allow repeated function
parameters.

We now return an error if a functions input or output parameter is a
repeated structure.

Closes #81