### PR TITLE
all: added debug information controlled by command line flags

### DIFF
--- a/generate/generate.go
+++ b/generate/generate.go
@@ -9,8 +9,6 @@ import (
 	"go/token"
 	"go/types"
 	"io/ioutil"
-	"os"
-	"os/exec"
 	"path/filepath"
 	"reflect"
 	"sort"
@@ -25,6 +23,7 @@ import (
 
 	"github.com/gunk/gunk/config"
 	"github.com/gunk/gunk/loader"
+	"github.com/gunk/gunk/log"
 )
 
 // Run generates the specified Gunk packages via protobuf generators, writing
@@ -82,6 +81,8 @@ func Run(dir string, args ...string) error {
 		if err := g.GeneratePkg(pkg.PkgPath, cfg.Generators); err != nil {
 			return err
 		}
+		log.PackageGenerated(pkg.PkgPath)
+
 	}
 	return nil
 }
@@ -218,9 +219,8 @@ func (g *Generator) generateProtoc(req plugin.CodeGeneratorRequest, gen config.G
 
 	args = append(args, protoFilenames...)
 
-	cmd := exec.Command(command, args...)
+	cmd := log.ExecCommand(command, args...)
 	cmd.Stdin = bytes.NewReader(bs)
-	cmd.Stderr = os.Stderr
 	out, err := cmd.Output()
 	if err != nil {
 		return fmt.Errorf("error executing %q: %q, %v", command, out, err)
@@ -235,9 +235,8 @@ func (g *Generator) generatePlugin(req plugin.CodeGeneratorRequest, gen config.G
 		return err
 	}
 
-	cmd := exec.Command(gen.Command)
+	cmd := log.ExecCommand(gen.Command)
 	cmd.Stdin = bytes.NewReader(bs)
-	cmd.Stderr = os.Stderr
 	out, err := cmd.Output()
 	if err != nil {
 		return fmt.Errorf("error executing %s: %s, %v", gen.Command, out, err)

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,8 @@ require (
 	github.com/rogpeppe/go-internal v1.0.0
 	github.com/stretchr/testify v1.2.2 // indirect
 	golang.org/x/net v0.0.0-20181029044818-c44066c5c816
-	golang.org/x/tools v0.0.0-20181030000716-a0a13e073c7b
+	golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33 // indirect
+	golang.org/x/tools v0.0.0-20181120060634-fc4f04983f62
 	google.golang.org/genproto v0.0.0-20181029155118-b69ba1387ce2
 	google.golang.org/grpc v1.16.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,7 @@ github.com/grpc-ecosystem/grpc-gateway v1.5.1 h1:3scN4iuXkNOyP98jF55Lv8a9j1o/Iwv
 github.com/grpc-ecosystem/grpc-gateway v1.5.1/go.mod h1:RSKVYQBd5MCa4OVpNdGskqpgL2+G+NZTnrVHpWWfpdw=
 github.com/gunk/opt v0.0.0-20181101130410-636bd718f80f h1:QXNv4Sic6WZs3FYadox4JNS6dOI2QlXzRS8WNVrlU48=
 github.com/gunk/opt v0.0.0-20181101130410-636bd718f80f/go.mod h1:mwnDF6IXLCA4xXLUMmG7usTLB6Mk+KGQelNF1u390gc=
+github.com/kisielk/gotool v1.0.0 h1:AV2c/EiW3KqPNT9ZKl07ehoAGi4C5/01Cfbblndcapg=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/knq/ini v0.0.0-20181118015158-a301e724bd35 h1:et/xKFFaPqT7bV8MOn5KVnNiqenWdE9KM8fPlni6z0g=
 github.com/knq/ini v0.0.0-20181118015158-a301e724bd35/go.mod h1:kWZM2Rp5R3eP4q91Xms9JPMXuH7+yQrfTd3ZVzhxTUE=
@@ -45,11 +46,13 @@ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f h1:wMNYb4v58l5UBM7MYRLPG6Zh
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522 h1:Ve1ORMCxvRmSXBwJK+t3Oy+V2vRW2OetUQBq4rJIkZE=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33 h1:I6FyU15t786LL7oL/hn43zqTuEGr4PN7F4XJ1p4E3Y8=
+golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20180828015842-6cd1fcedba52/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
-golang.org/x/tools v0.0.0-20181030000716-a0a13e073c7b h1:Un5iKMvgLIGMzGM1mJWvi22FiMX9XB6/NOzYKoy66y8=
-golang.org/x/tools v0.0.0-20181030000716-a0a13e073c7b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+golang.org/x/tools v0.0.0-20181120060634-fc4f04983f62 h1:1Q34CedRebzugYW3YoBK2ueHjonPQ6wiOEHoeQ1fCP4=
+golang.org/x/tools v0.0.0-20181120060634-fc4f04983f62/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20181029155118-b69ba1387ce2 h1:67iHsV9djwGdZpdZNbLuQj6FOzCaZe3w+vhLjn5AcFA=

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -16,6 +16,8 @@ import (
 	"github.com/golang/protobuf/proto"
 	desc "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"golang.org/x/tools/go/packages"
+
+	"github.com/gunk/gunk/log"
 )
 
 // Load loads the Gunk packages on the provided patterns from the given dir and
@@ -174,7 +176,7 @@ syntax = "proto3";
 	defer os.Remove("gunk-proto")
 
 	// TODO: any way to specify stdout while being portable?
-	cmd := exec.Command("protoc", "-o/dev/stdout", "--include_imports", "gunk-proto")
+	cmd := log.ExecCommand("protoc", "-o/dev/stdout", "--include_imports", "gunk-proto")
 	out, err := cmd.Output()
 	if err != nil {
 		if e, ok := err.(*exec.ExitError); ok {

--- a/log/log.go
+++ b/log/log.go
@@ -1,0 +1,43 @@
+package log
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+var (
+	PrintCommands = false
+	Verbose       = false
+)
+
+func Command(command string, args ...string) {
+	if !PrintCommands {
+		return
+	}
+	fmt.Printf("%s %s\n", command, strings.Join(args, " "))
+}
+
+func Log(format string, args ...interface{}) {
+	if !Verbose {
+		return
+	}
+	fmt.Printf(format, args...)
+}
+
+func PackageGenerated(pkgPath string) {
+	if !Verbose {
+		return
+	}
+	fmt.Println(pkgPath)
+}
+
+func ExecCommand(command string, args ...string) *exec.Cmd {
+	Command(command, args...)
+	cmd := exec.Command(command, args...)
+	if Verbose {
+		cmd.Stderr = os.Stdout
+	}
+	return cmd
+}

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gunk/gunk/convert"
 	"github.com/gunk/gunk/format"
 	"github.com/gunk/gunk/generate"
+	"github.com/gunk/gunk/log"
 )
 
 var (
@@ -30,6 +31,9 @@ func main() {
 }
 
 func main1() int {
+	gen.Flag("print-commands", "print the commands").Short('x').BoolVar(&log.PrintCommands)
+	gen.Flag("verbose", "print the names of packages as they are generated").Short('v').BoolVar(&log.Verbose)
+
 	var err error
 	switch kingpin.MustParse(app.Parse(os.Args[1:])) {
 	case gen.FullCommand():

--- a/testdata/scripts/generate_flags.txt
+++ b/testdata/scripts/generate_flags.txt
@@ -1,0 +1,31 @@
+env HOME=$WORK/home
+
+env PATH=$WORK/bin:$PATH
+exec chmod a+x bin/protoc
+
+gunk generate . -x
+stdout bin/protoc
+
+gunk generate . -v
+stdout 'hello gunk'
+stdout testdata.tld/util
+
+-- bin/protoc --
+#!/bin/sh
+
+echo hello gunk >&2
+
+exit 0
+-- go.mod --
+module testdata.tld/util
+-- .gunkconfig --
+[generate]
+command=bin/protoc
+-- doc.go --
+package util // make this directory a Go package
+-- echo.gunk --
+package util // proto "testdata.v1.util"
+
+type Util interface {
+	Echo() // use google.protobuf.Empty, which requires protoc
+}


### PR DESCRIPTION
Added '-x' and '-v' to 'gunk', they behave similar to Go. '-x' will
print any commands that are run, these currently include 'protoc',
'protoc-gen-*' and 'ls' commands. '-v' will print when a gunk package
has been generated, this currently also doubles as a 'verbose' like
flag, which will print out any stderr from a command.

Closes #91