### PR TITLE
testdata: remove unnecessary module deps

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -116,7 +116,7 @@ func generatedFiles(t *testing.T, dir string) (map[string]string, error) {
 	return files, err
 }
 
-func TestGenerateScripts(t *testing.T) {
+func TestScripts(t *testing.T) {
 	testscript.Run(t, testscript.Params{
 		Dir: filepath.Join("testdata", "scripts"),
 	})

--- a/testdata/scripts/config_noconfig.txt
+++ b/testdata/scripts/config_noconfig.txt
@@ -13,10 +13,6 @@ package util // make this directory a Go package
 -- gunk/util.gunk --
 package util
 
-import (
-	"github.com/gunk/opt/http"
-)
-
 type Message struct {
 	Msg string `pb:"1"`
 }


### PR DESCRIPTION
To make the test scripts completely independent and reproducible, each
test runs in its own directory, HOME, and Go environment, including
module cache.

This means that loading any Gunk packages that import packages from the
internet like gunk/opt will need to download them every time. This can
be slow, since downloading a module from GitHub requires a few http
roundtrips and won't be cached between test runs.

In the long run, we should use something like
github.com/rogpeppe/go-internal/goproxytest to provide a static module
proxy to the tests, so they can load the third packages we want in a
predictable way.

For now, simply removing the unnecessary import brings down the run time
of 'go test' from ~2.4s to ~0.8s on my laptop.