### PR TITLE
loader: add workaround for loading zero patterns

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -31,6 +31,11 @@ func Load(dir string, fset *token.FileSet, patterns ...string) ([]*GunkPackage, 
 		Dir:  dir,
 		Mode: packages.LoadFiles,
 	}
+	if len(patterns) == 0 {
+		// TODO(mvdan): remove once
+		// https://github.com/golang/go/issues/28767 is fixed
+		patterns = []string{"."}
+	}
 	lpkgs, err := packages.Load(cfg, patterns...)
 	if err != nil {
 		return nil, err

--- a/testdata/scripts/format.txt
+++ b/testdata/scripts/format.txt
@@ -8,12 +8,22 @@ stderr 'no Gunk packages to format'
 gunk format .
 cmp echo.gunk echo.gunk.golden
 
+# no args is equivalent to "."
+cd broken
+! gunk format
+stderr 'echo.gunk:1'
+cd ..
+
 -- go.mod --
 module testdata.tld/util
 -- doc.go --
 package util // make this directory a Go package
 -- empty/doc.go --
 package empty // make this directory a Go package
+-- broken/doc.go --
+package broken // make this directory a Go package
+-- broken/echo.gunk --
+package
 -- echo.gunk --
 package util   // proto "testdata.v1.util"
 


### PR DESCRIPTION
For now, until the upstream issue is resolved.

Fixes #59.