### PR TITLE
generate: configurable gunk options

### DIFF
--- a/testdata/scripts/generate_fileoptions.txt
+++ b/testdata/scripts/generate_fileoptions.txt
@@ -1,0 +1,30 @@
+env HOME=$WORK/home
+
+gunk generate ./normal
+exists normal/all.pb.go
+! grep 'all.proto is a deprecated file' normal/all.pb.go
+
+gunk generate ./deprecated
+exists deprecated/all.pb.go
+grep 'all.proto is a deprecated file' deprecated/all.pb.go
+
+-- go.mod --
+module testdata.tld/util
+-- .gunkconfig --
+[generate]
+command=protoc-gen-go
+
+-- normal/doc.go --
+package normal
+-- normal/normal.gunk --
+package normal
+
+-- deprecated/doc.go --
+package deprecated
+-- deprecated/deprecated.gunk --
+// +gunk opt.Deprecated(true)
+package deprecated
+
+import (
+    "github.com/gunk/opt"
+)


### PR DESCRIPTION
Allow the user to set '+gunk' tags in the package comment for
controlling the proto options. Currently only the options defined in
'github.com/gunk/opt/opt.gunk' are supported, these are:

- Deprecated
- JavaPackage
- JavaMultipleFiles

Updates #104