### PR TITLE
loader: perform all gunk loading here

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -40,7 +40,7 @@ func (g Generator) ParamString() string {
 		if p.Value != "" {
 			params[i] = fmt.Sprintf("%s=%s", p.Key, p.Value)
 		} else {
-			params[i] = fmt.Sprintf("%s", p.Key)
+			params[i] = p.Key
 		}
 	}
 	return strings.Join(params, ",")

--- a/testdata/generate/all.pb.go
+++ b/testdata/generate/all.pb.go
@@ -58,7 +58,7 @@ func (x Status) String() string {
 	return proto.EnumName(Status_name, int32(x))
 }
 func (Status) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_all_f0aa1144da1e7949, []int{0}
+	return fileDescriptor_all_a604d30130a3b3a1, []int{0}
 }
 
 // CheckStatusResponse is the response for a check status.
@@ -73,7 +73,7 @@ func (m *CheckStatusResponse) Reset()         { *m = CheckStatusResponse{} }
 func (m *CheckStatusResponse) String() string { return proto.CompactTextString(m) }
 func (*CheckStatusResponse) ProtoMessage()    {}
 func (*CheckStatusResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_all_f0aa1144da1e7949, []int{0}
+	return fileDescriptor_all_a604d30130a3b3a1, []int{0}
 }
 func (m *CheckStatusResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CheckStatusResponse.Unmarshal(m, b)
@@ -118,7 +118,7 @@ func (m *UtilTestRequest) Reset()         { *m = UtilTestRequest{} }
 func (m *UtilTestRequest) String() string { return proto.CompactTextString(m) }
 func (*UtilTestRequest) ProtoMessage()    {}
 func (*UtilTestRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_all_f0aa1144da1e7949, []int{1}
+	return fileDescriptor_all_a604d30130a3b3a1, []int{1}
 }
 func (m *UtilTestRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_UtilTestRequest.Unmarshal(m, b)
@@ -375,9 +375,9 @@ var _UtilTests_serviceDesc = grpc.ServiceDesc{
 	Metadata: "testdata.tld/util/all.proto",
 }
 
-func init() { proto.RegisterFile("testdata.tld/util/all.proto", fileDescriptor_all_f0aa1144da1e7949) }
+func init() { proto.RegisterFile("testdata.tld/util/all.proto", fileDescriptor_all_a604d30130a3b3a1) }
 
-var fileDescriptor_all_f0aa1144da1e7949 = []byte{
+var fileDescriptor_all_a604d30130a3b3a1 = []byte{
 	// 601 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x53, 0x4f, 0x6b, 0xd4, 0x5e,
 	0x14, 0x7d, 0xef, 0x4d, 0x26, 0xcd, 0xdc, 0xa1, 0xed, 0xf0, 0x7e, 0x50, 0x5e, 0x53, 0xf8, 0x75,

--- a/testdata/generate/all.pb.gw.go
+++ b/testdata/generate/all.pb.gw.go
@@ -21,7 +21,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/status"
-	imported_0 "testdata.tld/util/imported"
+	"testdata.tld/util/imported"
 )
 
 var _ codes.Code
@@ -31,7 +31,7 @@ var _ = runtime.String
 var _ = utilities.NewDoubleArray
 
 func request_Util_Echo_0(ctx context.Context, marshaler runtime.Marshaler, client UtilClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq imported_0.Message
+	var protoReq imported.Message
 	var metadata runtime.ServerMetadata
 
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {

--- a/testdata/scripts/eval.txt
+++ b/testdata/scripts/eval.txt
@@ -8,6 +8,9 @@ stderr 'p2.gunk:11:13: expected operand'
 
 -- go.mod --
 module testdata.tld/util
+-- .gunkconfig --
+[generate]
+command=protoc-gen-go
 -- p1/doc.go --
 package util // make this directory a Go package
 -- p1/p1.gunk --

--- a/testdata/scripts/format.txt
+++ b/testdata/scripts/format.txt
@@ -25,9 +25,14 @@ package broken // make this directory a Go package
 -- broken/echo.gunk --
 package
 -- echo.gunk --
-// +gunk opt.JavaPackage("com.testdata.v1")
-// +gunk opt.Deprecated(true)
+// +gunk java.Package("com.testdata.v1")
+// +gunk file.Deprecated(true)
 package util   // proto "testdata.v1.util"
+
+import (
+"github.com/gunk/opt/file"
+"github.com/gunk/opt/file/java"
+)
 
 type Message struct {
 Text string    `pb:"1" json:"text"`
@@ -53,9 +58,14 @@ Echo2(Message) Message
 }
 
 -- echo.gunk.golden --
-// +gunk opt.JavaPackage("com.testdata.v1")
-// +gunk opt.Deprecated(true)
+// +gunk java.Package("com.testdata.v1")
+// +gunk file.Deprecated(true)
 package util // proto "testdata.v1.util"
+
+import (
+	"github.com/gunk/opt/file"
+	"github.com/gunk/opt/file/java"
+)
 
 type Message struct {
 	Text string `pb:"1" json:"text"`


### PR DESCRIPTION
We were using the loader for two purposes. The simpler was the
formatter's use case, where we only need to parse the given packages.

The second and more complex is the generator's. It needs to parse the
given Gunk packages, all of their Gunk dependencies, and type-check all
of them including their gunk tags.

Before, all this extra work was done in the generator package. This
worked okay, but led to complex lazy loading and type-checking all over
the place.

Instead, have the loader package mirror go/packages more closely. By
default it will only do what the formatter needs. But if Types==true, it
will also typecheck the Gunk packages and their gunk tags, and
consequently do the same for all their transitive Gunk dependencies.

All the loading is entirely in the loader package, and the generate
package no longer evaluates tags in a handful of places.

Fixes #112.