### PR TITLE
testdata: use a static GOPROXY for the scripts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,8 +11,9 @@ require (
 	github.com/gunk/opt v0.0.0-20181129161359-767b03a66301 // indirect
 	github.com/knq/ini v0.0.0-20181118015158-a301e724bd35
 	github.com/knq/snaker v0.0.0-20180306023312-d9ad1e7f342a
+	github.com/kr/pty v1.1.3 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/rogpeppe/go-internal v1.0.0
+	github.com/rogpeppe/go-internal v1.0.1-alpha.3
 	github.com/stretchr/testify v1.2.2 // indirect
 	golang.org/x/net v0.0.0-20181029044818-c44066c5c816
 	golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33 // indirect

--- a/go.sum
+++ b/go.sum
@@ -29,12 +29,15 @@ github.com/knq/snaker v0.0.0-20180306023312-d9ad1e7f342a/go.mod h1:f0Dmq8fkddh8n
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/pty v1.1.3/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.0.0 h1:o4VLZ5jqHE+HahLT6drNtSGTrrUA3wPBmtpgqtdbClo=
 github.com/rogpeppe/go-internal v1.0.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/rogpeppe/go-internal v1.0.1-alpha.3 h1:Pu6L/AHdrTeRz8kQZd/RRxDLs4Vpl720/UfJZrjR4BQ=
+github.com/rogpeppe/go-internal v1.0.1-alpha.3/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 golang.org/x/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/testdata/mod/github.com_gunk_opt_v0.0.0-20181129161359-767b03a66301.txt
+++ b/testdata/mod/github.com_gunk_opt_v0.0.0-20181129161359-767b03a66301.txt
@@ -1,0 +1,220 @@
+module github.com/gunk/opt@latest
+
+-- .mod --
+module github.com/gunk/opt
+-- .info --
+{"Version":"v0.0.0-20181129161359-767b03a66301","Time":"2018-11-29T16:13:59Z"}
+-- README.md --
+-- enum/doc.go --
+package enum
+-- enum/enum.gunk --
+package enum
+
+// AllowAlias is the allow_alias option.
+type AllowAlias bool
+
+// Deprecated is the deprecated option.
+type Deprecated bool
+-- enumvalues/doc.go --
+package enumvalues
+-- enumvalues/enumvalues.gunk --
+package enumvalues
+
+// Deprecated is the deprecated option.
+type Deprecated bool
+-- field/cc/cc.gunk --
+package cc
+
+type Type int
+
+const (
+    String Type = iota
+    Cord
+    StringPiece
+)
+-- field/cc/doc.go --
+package cc
+-- field/doc.go --
+package field
+-- field/field.gunk --
+package field
+
+// Packed is the packed option.
+type Packed bool
+
+// Lazy is the lazy option.
+type Lazy bool
+
+// Deprecated is the deprecated option.
+type Deprecated bool
+-- field/js/doc.go --
+package js
+-- field/js/js.gunk --
+package js
+
+type Type int
+
+const (
+    Normal Type = iota
+    String
+    Number
+)
+-- file/cc/cc.gunk --
+package cc
+
+// EnableArenas is the cc_enable_arenas option.
+type EnableArenas bool
+
+// GenericServices is the cc_generic_services option.
+type GenericServices bool
+-- file/cc/doc.go --
+package cc
+
+// make this directory a Go package
+-- file/csharp/csharp.gunk --
+package csharp
+
+// Namespace is the csharp_namespace option.
+type Namespace string
+-- file/csharp/doc.go --
+package csharp
+
+// make this directory a Go package
+-- file/doc.go --
+package file
+
+// make this directory a Go package
+-- file/file.gunk --
+package file
+
+// Deprecated is the deprecated option.
+type Deprecated bool
+
+// OptimizeFor is the optimize_for option.
+type OptimizeFor int
+
+// Values for OptimizeFor enum.
+const (
+    Speed       OptimizeFor = 1 // default
+    CodeSize    OptimizeFor = 2
+    LiteRuntime OptimizeFor = 3
+)
+-- file/java/doc.go --
+package java
+
+// make this directory a Go package
+-- file/java/java.gunk --
+package java
+
+// Package is the java_package option.
+type Package string
+
+// OuterClassname is the java_outer_classname option.
+type OuterClassname string
+
+// MultipleFiles is the java_multiple_files option.
+type MultipleFiles bool
+
+// StringCheckUtf8 is the java_string_check_utf8 option.
+type StringCheckUtf8 bool
+
+// GenericServices is the java_generic_services option.
+type GenericServices bool
+-- file/objc/doc.go --
+package objc
+
+// make this directory a Go package
+-- file/objc/objc.gunk --
+package objc
+
+// ClassPrefix is the objc_class_prefix option.
+type ClassPrefix string
+-- file/php/doc.go --
+package php
+
+// make this directory a Go package
+-- file/php/php.gunk --
+package php
+
+// ClassPrefix is the php_class_prefix option.
+type ClassPrefix string
+
+// Namespace is the php_namespace option.
+type Namespace string
+
+// MetadataNamespace is the php_metadata_namespace option.
+type MetadataNamespace string
+
+// GenericServices is the php_generic_services option.
+type GenericServices bool
+-- file/ruby/doc.go --
+package ruby
+
+// make this directory a Go package
+-- file/ruby/ruby.gunk --
+package ruby
+
+// Package is the ruby_package option.
+type Package string
+-- file/swift/doc.go --
+package swift
+
+// make this directory a Go package
+-- file/swift/swift.gunk --
+package swift
+
+// Prefix is the swift_prefix option.
+type Prefix string
+-- go.mod --
+module github.com/gunk/opt
+-- http/doc.go --
+package http
+
+// make this directory a Go package
+-- http/http.gunk --
+// Package http provides the http matching options for gunk.
+package http
+
+// Match is the http matching option.
+type Match struct {
+    Method string `pb:"1"`
+    Path   string `pb:"2"`
+    Body   string `pb:"3"`
+}
+-- message/doc.go --
+package message
+-- message/message.gunk --
+package message
+
+// MessageSetWireFormat is the message_set_wire_format option.
+type MessageSetWireFormat bool
+
+// NoStandardDecriptorAccessor is the no_standard_descriptor_accessor option.
+type NoStandardDescriptorAccessor bool
+
+// Deprecated is the deprecated option.
+type Deprecated bool
+-- method/doc.go --
+package method
+-- method/method.gunk --
+package method
+
+// Deprecated is the deprecated option.
+type Deprecated bool
+
+// IdempotencyLevel is the idempotency_level option.
+type IdempotencyLevel int
+
+// Values for IdempotencyLevel
+const (
+    Unknown IdempotencyLevel = iota
+    NoSideEffects
+    Idempotent
+)
+-- service/doc.go --
+package service
+-- service/service.gunk --
+package service
+
+// Deprecated is the deprecated option.
+type Deprecated bool

--- a/testdata/scripts/generate_languages.txt
+++ b/testdata/scripts/generate_languages.txt
@@ -4,6 +4,10 @@ gunk generate ./util -v -x
 
 -- go.mod --
 module testdata.tld/util
+
+require (
+	github.com/gunk/opt v0.0.0-20181129161359-767b03a66301
+)
 -- v1/go/.empty --
 -- v1/python/.empty --
 -- v1/java/.empty --

--- a/testdata/scripts/generate_options.txt
+++ b/testdata/scripts/generate_options.txt
@@ -19,6 +19,10 @@ grep 'Msg .* // Deprecated: Do not use.' deprecated/all.pb.go
 
 -- go.mod --
 module testdata.tld/util
+
+require (
+	github.com/gunk/opt v0.0.0-20181129161359-767b03a66301
+)
 -- .gunkconfig --
 [generate]
 command=protoc-gen-go


### PR DESCRIPTION
A 'go test' with the cache warm now takes ~0.7s instead of ~4s on my
laptop.

The command used to "vendor" the module in this static GOPROXY was
github.com/rogpeppe/go-internal/cmd/txtar-addmod:

	txtar-addmod -all testdata/mod github.com/gunk/opt@latest

Finally, we need to add the same version requires to each test go.mod
file, so that we don't have to figure out which version is latest at
each test run.

Fixes #119.