### PR TITLE
loader: remove the need for doc.go files

### DIFF
--- a/testdata/scripts/config.txt
+++ b/testdata/scripts/config.txt
@@ -17,9 +17,6 @@ plugins=grpc
 [generate]
 protoc=python
 
--- gunk/doc.go --
-package util // make this directory a Go package
-
 -- gunk/util.gunk --
 package util
 

--- a/testdata/scripts/config_merge.txt
+++ b/testdata/scripts/config_merge.txt
@@ -18,9 +18,6 @@ plugins=grpc
 [generate]
 protoc=python
 
--- gunk/doc.go --
-package util // make this directory a Go package
-
 -- gunk/util.gunk --
 package util
 

--- a/testdata/scripts/config_noconfig.txt
+++ b/testdata/scripts/config_noconfig.txt
@@ -7,9 +7,6 @@ stderr 'unable to load gunkconfig: no .gunkconfig found'
 -- go.mod --
 module testdata.tld/util
 
--- gunk/doc.go --
-package util // make this directory a Go package
-
 -- gunk/util.gunk --
 package util
 

--- a/testdata/scripts/config_projectroot.txt
+++ b/testdata/scripts/config_projectroot.txt
@@ -25,8 +25,6 @@ exists gomod/all.pb.go
 [generate]
 command=protoc-gen-go
 plugins=grpc
--- gitfolder/doc.go --
-package util // make this directory a Go package
 -- gitfolder/util.gunk --
 package util
 
@@ -44,8 +42,6 @@ type Util interface {
 [generate]
 command=protoc-gen-go
 plugins=grpc
--- gitfile/doc.go --
-package util // make this directory a Go package
 -- gitfile/util.gunk --
 package util
 
@@ -63,8 +59,6 @@ type Util interface {
 [generate]
 command=protoc-gen-go
 plugins=grpc
--- gomod/doc.go --
-package util // make this directory a Go package
 -- gomod/util.gunk --
 package util
 

--- a/testdata/scripts/config_with_out.txt
+++ b/testdata/scripts/config_with_out.txt
@@ -24,9 +24,6 @@ plugins=grpc
 out=v1/
 protoc=python
 
--- gunk/doc.go --
-package util // make this directory a Go package
-
 -- gunk/util.gunk --
 package util
 

--- a/testdata/scripts/empty.txt
+++ b/testdata/scripts/empty.txt
@@ -15,11 +15,9 @@ gunk generate ./...
 module testdata.tld/util
 -- .gunkconfig --
 # Empty gunkconfig
--- doc.go --
-package util // make this directory a Go package
--- p2/doc.go --
-package p2 // make this directory a Go package
--- p3/doc.go --
-package p3 // make this directory a Go package
+-- empty.go --
+package util // no Gunk files
+-- p2/empty.go --
+package p2 // no Gunk files
 -- p3/echo.gunk --
 package p3

--- a/testdata/scripts/envs.txt
+++ b/testdata/scripts/envs.txt
@@ -22,8 +22,6 @@ exit 1
 module testdata.tld/util
 -- .gunkconfig --
 [generate python]
--- doc.go --
-package util // make this directory a Go package
 -- echo.gunk --
 package util // proto "testdata.v1.util"
 

--- a/testdata/scripts/eval.txt
+++ b/testdata/scripts/eval.txt
@@ -11,8 +11,6 @@ module testdata.tld/util
 -- .gunkconfig --
 [generate]
 command=protoc-gen-go
--- p1/doc.go --
-package util // make this directory a Go package
 -- p1/p1.gunk --
 package util
 
@@ -27,8 +25,6 @@ type Util interface {
 	// }
 	Echo(Message) Message
 }
--- p2/doc.go --
-package util // make this directory a Go package
 -- p2/p2.gunk --
 package util
 

--- a/testdata/scripts/format.txt
+++ b/testdata/scripts/format.txt
@@ -16,12 +16,8 @@ cd ..
 
 -- go.mod --
 module testdata.tld/util
--- doc.go --
-package util // make this directory a Go package
--- empty/doc.go --
-package empty // make this directory a Go package
--- broken/doc.go --
-package broken // make this directory a Go package
+-- empty/empty.go --
+package empty // no Gunk files
 -- broken/echo.gunk --
 package
 -- echo.gunk --

--- a/testdata/scripts/format_missingnumbers.txt
+++ b/testdata/scripts/format_missingnumbers.txt
@@ -8,16 +8,12 @@ stderr 'error/message.gunk:4:11: struct field tag for pb was empty, please remov
 
 -- go.mod --
 module testdata.tld/message
--- error/doc.go --
-package message
 -- error/message.gunk --
 package message
 
 type Message struct {
 	Code int `pb:""` // Currently we are unable to handle the case where pb is empty
 }
--- doc.go --
-package message
 -- message.gunk --
 package message
 

--- a/testdata/scripts/generate_flags.txt
+++ b/testdata/scripts/generate_flags.txt
@@ -21,8 +21,6 @@ module testdata.tld/util
 -- .gunkconfig --
 [generate]
 command=bin/protoc
--- doc.go --
-package util // make this directory a Go package
 -- echo.gunk --
 package util // proto "testdata.v1.util"
 

--- a/testdata/scripts/generate_languages.txt
+++ b/testdata/scripts/generate_languages.txt
@@ -45,8 +45,6 @@ out=v1/cpp
 
 [generate objc]
 out=v1/objc
--- util/doc.go --
-package util
 -- util/util.gunk --
 package util
 

--- a/testdata/scripts/generate_options.txt
+++ b/testdata/scripts/generate_options.txt
@@ -29,13 +29,9 @@ command=protoc-gen-go
 
 [generate java]
 [generate python]
--- normal/doc.go --
-package normal
 -- normal/normal.gunk --
 package normal
 
--- deprecated/doc.go --
-package deprecated
 -- deprecated/deprecated.gunk --
 // +gunk file.Deprecated(true)
 // +gunk java.Package("com.example.deprecated")

--- a/testdata/scripts/generate_unused_imports.txt
+++ b/testdata/scripts/generate_unused_imports.txt
@@ -11,8 +11,6 @@ module testdata.tld/util
 -- .gunkconfig --
 [generate]
 command=protoc-gen-go
--- doc.go --
-package util // make this directory a Go package
 -- echo.gunk --
 package util // proto "testdata.v1.util"
 
@@ -28,8 +26,6 @@ type Code struct {
 type Util interface {
 	Echo(Code) Code
 }
--- v1/doc.go --
-package message // make this directory a Go package
 -- v1/message.gunk --
 package message
 
@@ -37,8 +33,6 @@ type Message struct {
 	Msg string `pb:"1"`
 }
 
--- v2/doc.go --
-package code // make this directory a Go package
 -- v2/message.gunk --
 package code
 

--- a/testdata/scripts/repeated_function_param.txt
+++ b/testdata/scripts/repeated_function_param.txt
@@ -9,8 +9,6 @@ stderr 'error: parameter type should not be repeated'
 -- go.mod --
 module testdata.tld/util
 -- .gunkconfig --
--- p1/doc.go --
-package util // make this directory a Go package
 -- p1/p1.gunk --
 package util
 
@@ -22,8 +20,6 @@ type Util interface {
 	// Echo echoes a message.
 	Echo(Message) []Message
 }
--- p2/doc.go --
-package util // make this directory a Go package
 -- p2/p2.gunk --
 package util
 


### PR DESCRIPTION
loader: remove the need for doc.go files

We needed these files to make Gunk packages always be Go packages too.
Otherwise, if a directory has zero Go files, a command like 'go list
./...' would skip them.

However, that was a terrible hack to work around an implementation
detail, and it should have never been visible to the user. Requiring the
user to add doc.go files is unnecessary and a bit annoying.

For now, work around the issue by adding temporary Go files to all Gunk
packages that need them. Use randomized filenames, so that concurrent
gunk calls don't step on each other.

Since we can't know what directories a list of patterns should expand to
before adding these temporary Go files, we do the next best thing - we
walk the tree, looking for Gunk packages with zero Go files. We do this
recursively from the module root if there's a module, or from the
current directory otherwise.

Fixes #89.