### PR TITLE
tests: fix config_projectroot test

### DIFF
--- a/testdata/scripts/config_projectroot.txt
+++ b/testdata/scripts/config_projectroot.txt
@@ -54,7 +54,7 @@ type Util interface {
 	Echo(Message) Message
 }
 
--- gomod/.git --
+-- gomod/go.mod --
 -- gomod/.gunkconfig --
 [generate]
 command=protoc-gen-go


### PR DESCRIPTION
We were testing for a '.git' directory instead of a 'go.mod' file in the
test for when 'go.mod' is the project root. Changed '.git' to 'go.mod'
to correctly test the case where a 'go.mod' file is the project root.

Fixes #121