### PR TITLE
generate: add missing type mappings

### DIFF
--- a/generate/generate.go
+++ b/generate/generate.go
@@ -895,13 +895,23 @@ func (g *Generator) qualifiedTypeName(typeName string, pkg *types.Package) strin
 func (g *Generator) convertType(typ types.Type) (desc.FieldDescriptorProto_Type, desc.FieldDescriptorProto_Label, string) {
 	switch typ := typ.(type) {
 	case *types.Basic:
-		// Map Go types to proto types via
+		// Map Go types to proto types:
 		// https://developers.google.com/protocol-buffers/docs/proto3#scalar
 		switch typ.Kind() {
 		case types.String:
 			return desc.FieldDescriptorProto_TYPE_STRING, desc.FieldDescriptorProto_LABEL_OPTIONAL, ""
 		case types.Int, types.Int32:
 			return desc.FieldDescriptorProto_TYPE_INT32, desc.FieldDescriptorProto_LABEL_OPTIONAL, ""
+		case types.Uint, types.Uint32:
+			return desc.FieldDescriptorProto_TYPE_UINT32, desc.FieldDescriptorProto_LABEL_OPTIONAL, ""
+		case types.Int64:
+			return desc.FieldDescriptorProto_TYPE_INT64, desc.FieldDescriptorProto_LABEL_OPTIONAL, ""
+		case types.Uint64:
+			return desc.FieldDescriptorProto_TYPE_UINT64, desc.FieldDescriptorProto_LABEL_OPTIONAL, ""
+		case types.Float32:
+			return desc.FieldDescriptorProto_TYPE_FLOAT, desc.FieldDescriptorProto_LABEL_OPTIONAL, ""
+		case types.Float64:
+			return desc.FieldDescriptorProto_TYPE_DOUBLE, desc.FieldDescriptorProto_LABEL_OPTIONAL, ""
 		case types.Bool:
 			return desc.FieldDescriptorProto_TYPE_BOOL, desc.FieldDescriptorProto_LABEL_OPTIONAL, ""
 		}

--- a/testdata/scripts/generate_mappings.txt
+++ b/testdata/scripts/generate_mappings.txt
@@ -1,0 +1,38 @@
+env HOME=$WORK/home
+
+gunk generate .
+exists all.pb.go
+
+# Check that the types conversion from gunk -> proto -> go
+# are the correct type mappings.
+grep 'Bool.*bool' all.pb.go
+grep 'String.*string' all.pb.go
+grep 'Int.*int32' all.pb.go
+grep 'Int32.*int32' all.pb.go
+grep 'Uint.*uint32' all.pb.go
+grep 'Uint32.*uint32' all.pb.go
+grep 'Int64.*int64' all.pb.go
+grep 'Uint64.*uint64' all.pb.go
+grep 'Float.*float32' all.pb.go
+grep 'Double.*float64' all.pb.go
+grep 'Slice.*\[\]int32' all.pb.go
+
+-- .gunkconfig --
+[generate]
+command=protoc-gen-go
+-- mappings.gunk --
+package mappings
+
+type Message struct {
+    Bool bool `pb:"1"`
+	String string `pb:"2"`
+    Int int `pb:"3"`
+    Int32 int32 `pb:"4"`
+    Uint uint `pb:"5"`
+    Uint32 uint32 `pb:"6"`
+    Int64 int64 `pb:"7"`
+    Uint64 uint64 `pb:"8"`
+    Float float32 `pb:"9"`
+    Double float64 `pb:"10"`
+    Slice []int `pb:"11"`
+}


### PR DESCRIPTION
Added the following missing type conversions from gunk (go) -> proto:

- uint -> FieldDescriptorProto_TYPE_UINT32
- uint32 -> FieldDescriptorProto_TYPE_UINT32
- int64 -> FieldDescriptorProto_TYPE_INT64
- uint64 -> FieldDescriptorProto_TYPE_UINT64
- float32 -> FieldDescriptorProto_TYPE_FLOAT
- float64 -> FieldDescriptorProto_TYPE_DOUBLE

Fixes #115