### PR TITLE
config: allow shortened generate sections for protoc-gen-*

### DIFF
--- a/testdata/scripts/generate_languages.txt
+++ b/testdata/scripts/generate_languages.txt
@@ -18,9 +18,8 @@ require (
 -- v1/cpp/.empty --
 -- v1/objc/.empty --
 -- .gunkconfig --
-[generate]
+[generate go]
 out=v1/go
-command=protoc-gen-go
 
 [generate python]
 out=v1/python


### PR DESCRIPTION
'protoc-gen-*' generators can now be used as shortened generate sections
in the gunkconfig. Previously, we just assumed that any
'[generate <x>]' in the gunkconfig should be passed through as 'proto --<x>_out'.
Now, we can have '[generate go]' and this will check for a 'protoc-gen-go' binary,
if it exsists that is used, otherwise it falls back to being passed
through to protoc.

Fixes #96