### PR TITLE
all: add -h as a short version of --help

### DIFF
--- a/main.go
+++ b/main.go
@@ -31,6 +31,8 @@ func main() {
 }
 
 func main1() int {
+	app.HelpFlag.Short('h') // allow -h as well as --help
+
 	gen.Flag("print-commands", "print the commands").Short('x').BoolVar(&log.PrintCommands)
 	gen.Flag("verbose", "print the names of packages as they are generated").Short('v').BoolVar(&log.Verbose)
 

--- a/main_test.go
+++ b/main_test.go
@@ -18,9 +18,9 @@ import (
 var write = flag.Bool("w", false, "overwrite testdata output files")
 
 func TestMain(m *testing.M) {
-	flag.Parse()
 
 	if os.Getenv("TESTSCRIPT_COMMAND") == "" {
+		flag.Parse()
 		// Don't put the binaries in a temporary directory to delete, as that
 		// means we have to re-link them every single time. That's quite
 		// expensive, at around half a second per 'go test' invocation.

--- a/testdata/scripts/cmds.txt
+++ b/testdata/scripts/cmds.txt
@@ -2,20 +2,35 @@ gunk
 stderr '^usage: gunk \['
 ! stdout .
 
-gunk help
+gunk -h
 stderr '^usage: gunk \['
 ! stdout .
 
-gunk generate --help
-stderr '^usage: gunk generate'
+gunk --help
+stderr '^usage: gunk \['
+! stdout .
+
+gunk help
+stderr '^usage: gunk \['
 ! stdout .
 
 gunk help generate
 stderr '^usage: gunk generate'
 ! stdout .
 
+! gunk help missing
+stderr 'expected command'
+
 ! gunk missing
 stderr 'expected command'
+
+gunk generate -h
+stderr '^usage: gunk generate'
+! stdout .
+
+gunk generate --help
+stderr '^usage: gunk generate'
+! stdout .
 
 ! gunk generate --missing
 stderr 'unknown long flag'


### PR DESCRIPTION
All the go tools accept this flag, so we should too.

Fixes #129.