### PR TITLE
all: run tests in parallel

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -54,6 +54,7 @@ func TestMain(m *testing.M) {
 var proxyURL string
 
 func TestGenerate(t *testing.T) {
+	t.Parallel()
 	pkgs := []string{
 		".", "./imported",
 	}
@@ -128,6 +129,7 @@ func generatedFiles(t *testing.T, dir string) (map[string]string, error) {
 }
 
 func TestScripts(t *testing.T) {
+	t.Parallel()
 	testscript.Run(t, testscript.Params{
 		Dir: filepath.Join("testdata", "scripts"),
 		Setup: func(e *testscript.Env) error {


### PR DESCRIPTION
The script tests were running in parallel among themselves already,
which is built into testscript. However, they weren't running in
parallel to TestGenerate.

TestGenerate and some of the script tests are the slowest without maxing
out on cpu, so this reduces 'go test' time on my laptop on battery from
~2.4s to ~1.4s.

TestGenerate writes to files in testdata/generate, but that's still fine
for t.Parallel - since that means it can run in parallel with other
parallel tests, but not itself.