### PR TITLE
dump: command that outputs filedescriptorset

### DIFF
--- a/dump/dump.go
+++ b/dump/dump.go
@@ -1,0 +1,40 @@
+package dump
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/gunk/gunk/generate"
+)
+
+// Run will generate the FileDescriptorSet for a Gunk package, and
+// output it as required.
+func Run(format, dir string, patterns ...string) error {
+	// Load the Gunk package and generate the FileDescriptorSet for the
+	// Gunk package.
+	fds, err := generate.FileDescriptorSet(dir, patterns...)
+	if err != nil {
+		return err
+	}
+
+	// Format the FileDescriptorSet.
+	var bs []byte
+	switch format {
+	case "json":
+		bs, err = json.Marshal(fds)
+	case "", "raw":
+		// The default format.
+		bs, err = proto.Marshal(fds)
+		if err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("unknown output format %q", format)
+	}
+
+	// Otherwise, output to stdout
+	_, err = os.Stdout.Write(bs)
+	return err
+}

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/gunk/gunk/convert"
+	"github.com/gunk/gunk/dump"
 	"github.com/gunk/gunk/format"
 	"github.com/gunk/gunk/generate"
 	"github.com/gunk/gunk/log"
@@ -24,6 +25,10 @@ var (
 
 	frmt         = app.Command("format", "Format Gunk code.")
 	frmtPatterns = frmt.Arg("patterns", "patterns of Gunk packages").Strings()
+
+	dmp         = app.Command("dump", "Write a FileDescriptorSet (a protocol buffer, defined in descriptor.proto)")
+	dmpPatterns = dmp.Arg("patterns", "patterns of Gunk packages").Strings()
+	dmpFormat   = dmp.Flag("format", "output format to write FileDescriptorSet as (options are 'raw' or 'json'").String()
 )
 
 func main() {
@@ -44,6 +49,8 @@ func main1() int {
 		err = convert.Run(*convProtoFile, *convOverwriteGunkFile)
 	case frmt.FullCommand():
 		err = format.Run("", *frmtPatterns...)
+	case dmp.FullCommand():
+		err = dump.Run(*dmpFormat, "", *dmpPatterns...)
 	}
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)


### PR DESCRIPTION
Added a new 'dump' command that outputs a single Gunk package's
FileDescriptorSet (as specified in descriptor.proto). This should help
when trying to debug the differences between what Gunk and Protoc
generate.

The dump command will output in 'raw' format as default (the same as
protoc -o), but can be specified to dump as 'json' format. The output
will be sent to stdout by default, but can also be written to a file.

Fixes #136