### PR TITLE
generate: sort protofile dependencies

### DIFF
--- a/generate/generate.go
+++ b/generate/generate.go
@@ -279,6 +279,20 @@ func (g *Generator) requestForPkg(pkgPath string) *plugin.CodeGeneratorRequest {
 		return *req.ProtoFile[i].Name < *req.ProtoFile[j].Name
 	})
 
+	// Super dumb approach to get which ProtoFile's depend on
+	// other ProtoFiles. This works because we don't load
+	// many protofiles at the moment and the ones we do load
+	// don't depend on each other.
+	independentProtoFiles := make([]*desc.FileDescriptorProto, 0, len(req.GetProtoFile()))
+	dependentProtoFiles := make([]*desc.FileDescriptorProto, 0, len(req.GetProtoFile()))
+	for _, f := range req.GetProtoFile() {
+		if len(f.GetDependency()) == 0 {
+			independentProtoFiles = append(independentProtoFiles, f)
+		} else {
+			dependentProtoFiles = append(dependentProtoFiles, f)
+		}
+	}
+	req.ProtoFile = append(independentProtoFiles, dependentProtoFiles...)
 	return req
 }
 


### PR DESCRIPTION
Attempt to sort the FileDescriptorSet in an order such that any proto
files without dependencies are first in the list, and the rest are at
the end.

Use a fairly dumb, but simple approach to determine which protofile's
depend on others. We can use this approach because we don't load that
many protofile's, and the ones we do load don't depend on each other.

This is required to fix an issue with the protoc nodejs grpc generator,
which seems to expect the protofiles to be in an order where any
depdendent protofile's are earlier on in the list.

Fixes #137