### PR TITLE
convert: output service methods correctly

### DIFF
--- a/convert/convert.go
+++ b/convert/convert.go
@@ -397,15 +397,18 @@ func (b *builder) handleService(s *proto.Service) error {
 				// for now?
 				return b.formatError(r.Position, "%s option is not yet handled", n)
 			}
-
-			// If the request type is the known empty parameter we can convert
-			// this to gunk as an empty function parameter.
-			if r.RequestType != "google.protobuf.Empty" {
-				b.format(w, 1, comment, "%s(%s) %s\n", r.Name, r.RequestType, r.ReturnsType)
-			} else {
-				b.format(w, 1, comment, "%s() %s\n", r.Name, r.ReturnsType)
-			}
 		}
+		// If the request type is the known empty parameter we can convert
+		// this to gunk as an empty function parameter.
+		requestType := r.RequestType
+		returnsType := r.ReturnsType
+		if requestType == "google.protobuf.Empty" {
+			requestType = ""
+		}
+		if returnsType == "google.protobuf.Empty" {
+			returnsType = ""
+		}
+		b.format(w, 1, comment, "%s(%s) %s\n", r.Name, requestType, returnsType)
 	}
 	b.format(w, 0, nil, "}")
 	b.translatedDeclarations = append(b.translatedDeclarations, w.String())

--- a/testdata/scripts/convert.txt
+++ b/testdata/scripts/convert.txt
@@ -1,0 +1,91 @@
+env HOME=$WORK/home
+
+gunk convert util.proto
+cmp util.gunk util.gunk.golden
+
+-- util.proto --
+syntax = "proto3";
+
+package util;
+
+import "google/protobuf/empty.proto";
+import "google/api/annotations.proto";
+
+enum Status {
+    UnknownStatus = 0;
+    Created       = 1;
+    Pending       = 2;
+    SUCCESS       = 3;
+    Failed        = 4;
+};
+
+message Msg {
+    string msg = 1;
+}
+
+service MsgService {
+    rpc Echo(Msg) returns (Msg) {}
+    rpc Handle(Msg) returns (google.protobuf.Empty) {}
+    rpc Result(google.protobuf.Empty) returns (Msg) {}
+}
+
+service HttpService {
+    rpc Get(Msg) returns (Msg) {
+        option (google.api.http) = {
+            get: "/v1/util"
+        }
+    }
+    rpc Post(Msg) returns (google.protobuf.Empty) {
+        option (google.api.http) = {
+            post: "/v1/util"
+            body: "*"
+        }
+    }
+}
+
+-- util.gunk.golden --
+package util
+
+import (
+	"github.com/gunk/opt"
+	"github.com/gunk/opt/http"
+	// "google/protobuf/empty.proto"
+	// "google/api/annotations.proto"
+)
+
+type Status int
+
+const (
+	UnknownStatus Status = iota
+	Created
+	Pending
+	SUCCESS
+	Failed
+)
+
+type Msg struct {
+	Msg string `pb:"1" json:"msg"`
+}
+
+type MsgService interface {
+	Echo(Msg) Msg
+
+	Handle(Msg)
+
+	Result() Msg
+}
+
+type HttpService interface {
+	// +gunk http.Match{
+	//     Method: "GET",
+	//     Path: "/v1/util",
+	// }
+	Get(Msg) Msg
+
+	// +gunk http.Match{
+	//     Method: "POST",
+	//     Path: "/v1/util",
+	//     Body: "*",
+	// }
+	Post(Msg)
+}


### PR DESCRIPTION
The code for converting the proto service methods into Gunk interface
methods was inside the incorrect forloop and therefore wasn't getting
called.

Also fix an issue with not outputting the empty parameter correctly in
both the request and returns parameter.

Updates #141