### PR TITLE
convert: allow proto files and folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,12 +185,12 @@ binary
 
 ## Convert
 
-Gunk provides functionality to convert a proto file to a Gunk file.
+Gunk provides functionality to convert proto files or folders to a Gunk file.
 
-    gunk convert path/to/file.proto
+    gunk convert path/to/file.proto other/path/to/file.proto
+    gunk convert ./path/to/proto/dir
 
-This will convert your proto file to the equivalent Gunk file. Currently
-this only works for single proto files.
+This will convert your proto file to the equivalent Gunk file.
 
 ## Gunk Annotations
 

--- a/convert/convert.go
+++ b/convert/convert.go
@@ -35,9 +35,49 @@ type builder struct {
 	imports []*proto.Import
 }
 
-// Run converts a proto file to a gunk file, saving the file in the same folder
-// as the proto file.
-func Run(path string, overwrite bool) error {
+// Run converts proto files or folders to gunk files, saving the files in
+// the same folder as the proto file.
+func Run(paths []string, overwrite bool) error {
+	for _, path := range paths {
+		if err := run(path, overwrite); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func run(path string, overwrite bool) error {
+
+	fi, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	// Determine whether the path is a file or a directory.
+	// If it is a file convert the file.
+	if !fi.IsDir() {
+		return convertFile(path, overwrite)
+	} else if filepath.Ext(path) == ".proto" {
+		// If the path is a directory and has a .proto extension then error.
+		return fmt.Errorf("%s is a directory, should be a proto file.", path)
+	}
+
+	// Handle the case where it is a directory. Loop through
+	// the files and if we have a .proto file attempt to
+	// convert it.
+	files, err := ioutil.ReadDir(path)
+	for _, f := range files {
+		// If the file is not a .proto file
+		if f.IsDir() || filepath.Ext(f.Name()) != ".proto" {
+			continue
+		}
+		if err := convertFile(filepath.Join(path, f.Name()), overwrite); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func convertFile(path string, overwrite bool) error {
 	if filepath.Ext(path) != ".proto" {
 		return fmt.Errorf("convert requires a .proto file")
 	}

--- a/go.mod
+++ b/go.mod
@@ -12,9 +12,11 @@ require (
 	github.com/knq/snaker v0.0.0-20181215144011-2bc8a4db4687
 	github.com/rogpeppe/go-internal v1.0.1-alpha.6
 	github.com/stretchr/testify v1.3.0 // indirect
+	golang.org/x/net v0.0.0-20181106065722-10aee1819953
 	golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 // indirect
 	golang.org/x/tools v0.0.0-20190111214448-fc1d57b08d7b
 	google.golang.org/genproto v0.0.0-20190111180523-db91494dd46c
+	google.golang.org/grpc v1.16.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/yaml.v2 v2.2.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,7 @@ github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/grpc-ecosystem/grpc-gateway v1.6.4 h1:xlu6C2WU6gvXt3XLyVpsgweaIL4VCmTjEsEAIt7qFqQ=
 github.com/grpc-ecosystem/grpc-gateway v1.6.4/go.mod h1:RSKVYQBd5MCa4OVpNdGskqpgL2+G+NZTnrVHpWWfpdw=
+github.com/kisielk/gotool v1.0.0 h1:AV2c/EiW3KqPNT9ZKl07ehoAGi4C5/01Cfbblndcapg=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/knq/ini v0.0.0-20181118015158-a301e724bd35 h1:et/xKFFaPqT7bV8MOn5KVnNiqenWdE9KM8fPlni6z0g=
 github.com/knq/ini v0.0.0-20181118015158-a301e724bd35/go.mod h1:kWZM2Rp5R3eP4q91Xms9JPMXuH7+yQrfTd3ZVzhxTUE=
@@ -38,13 +39,16 @@ github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 golang.org/x/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20181106065722-10aee1819953 h1:LuZIitY8waaxUfNIdtajyE/YzA/zyf0YxXG27VpLrkg=
 golang.org/x/net v0.0.0-20181106065722-10aee1819953/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f h1:wMNYb4v58l5UBM7MYRLPG6ZhfOqbKu7X5eyFl8ZhKvA=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 h1:YUO/7uOKsKeq9UokNS62b8FYywz3ker1l1vDZRCRefw=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sys v0.0.0-20180830151530-49385e6e1522 h1:Ve1ORMCxvRmSXBwJK+t3Oy+V2vRW2OetUQBq4rJIkZE=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20180828015842-6cd1fcedba52/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190111214448-fc1d57b08d7b h1:Z5QW7z0ycYrOVRYv3z4FeSZbRNvVwUfXHKQSZKb5A6w=
@@ -53,6 +57,7 @@ google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9Ywl
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190111180523-db91494dd46c h1:LZllHYjdJnynBfmwysp+s4yhMzfc+3BzhdqzAMvwjoc=
 google.golang.org/genproto v0.0.0-20190111180523-db91494dd46c/go.mod h1:7Ep/1NZk928CDR8SjdVbjWNpdIf6nzjE3BTgJDr2Atg=
+google.golang.org/grpc v1.16.0 h1:dz5IJGuC2BB7qXR5AyHNwAUBhZscK2xVez7mznh72sY=
 google.golang.org/grpc v1.16.0/go.mod h1:0JHn/cJsOMiMfNA9+DeHDlAU7KAAB5GDlYFpa9MZMio=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=

--- a/main.go
+++ b/main.go
@@ -19,9 +19,9 @@ var (
 	gen         = app.Command("generate", "Generate code from Gunk packages.")
 	genPatterns = gen.Arg("patterns", "patterns of Gunk packages").Strings()
 
-	conv                  = app.Command("convert", "Convert Proto file to Gunk file.")
-	convProtoFile         = conv.Arg("file", "Proto file to convert to Gunk").String()
-	convOverwriteGunkFile = conv.Flag("overwrite", "overwrite the converted Gunk file if it exists.").Bool()
+	conv                    = app.Command("convert", "Convert Proto file to Gunk file.")
+	convProtoFilesOrFolders = conv.Arg("files_or_folders", "Proto files or folders to convert to Gunk").Strings()
+	convOverwriteGunkFile   = conv.Flag("overwrite", "overwrite the converted Gunk file if it exists.").Bool()
 
 	frmt         = app.Command("format", "Format Gunk code.")
 	frmtPatterns = frmt.Arg("patterns", "patterns of Gunk packages").Strings()
@@ -46,7 +46,7 @@ func main1() int {
 	case gen.FullCommand():
 		err = generate.Run("", *genPatterns...)
 	case conv.FullCommand():
-		err = convert.Run(*convProtoFile, *convOverwriteGunkFile)
+		err = convert.Run(*convProtoFilesOrFolders, *convOverwriteGunkFile)
 	case frmt.FullCommand():
 		err = format.Run("", *frmtPatterns...)
 	case dmp.FullCommand():

--- a/testdata/scripts/convert_files_and_folders.txt
+++ b/testdata/scripts/convert_files_and_folders.txt
@@ -1,0 +1,65 @@
+env home=$work/home
+
+gunk convert util.proto ./util
+cmp util.gunk util.gunk.golden
+cmp util/util2.gunk util/util2.gunk.golden
+
+-- util.proto --
+syntax = "proto3";
+
+package util;
+
+enum status {
+    unknownstatus = 0;
+    created       = 1;
+    pending       = 2;
+    success       = 3;
+    failed        = 4;
+};
+
+-- util.gunk.golden --
+package util
+
+import (
+	"github.com/gunk/opt"
+	"github.com/gunk/opt/http"
+)
+
+type status int
+
+const (
+	unknownstatus status = iota
+	created
+	pending
+	success
+	failed
+)
+-- util/non-proto-file --
+-- util/util2.proto --
+syntax = "proto3";
+
+package util;
+
+enum status {
+    unknownstatus = 0;
+    created       = 1;
+    pending       = 2;
+    failed        = 4;
+};
+
+-- util/util2.gunk.golden --
+package util
+
+import (
+	"github.com/gunk/opt"
+	"github.com/gunk/opt/http"
+)
+
+type status int
+
+const (
+	unknownstatus status = 0
+	created       status = 1
+	pending       status = 2
+	failed        status = 4
+)


### PR DESCRIPTION
Accept a list of files and folders for the convert command and run
these through the converter. Only '.proto' files are converted to Gunk
files.

Updated readme.

Update github.com/emicklei/proto to 1.6.8.

Fixes #134