### PR TITLE
convert: proto fileoptions

### DIFF
--- a/testdata/scripts/convert.txt
+++ b/testdata/scripts/convert.txt
@@ -47,7 +47,6 @@ service HttpService {
 package util
 
 import (
-	"github.com/gunk/opt"
 	"github.com/gunk/opt/http"
 	// "google/protobuf/empty.proto"
 	// "google/api/annotations.proto"

--- a/testdata/scripts/convert_fileoptions.txt
+++ b/testdata/scripts/convert_fileoptions.txt
@@ -1,0 +1,25 @@
+env HOME=$WORK/home
+
+gunk convert util.proto
+cmp util.gunk util.gunk.golden
+
+-- util.proto --
+syntax = "proto3";
+
+package util;
+
+option optimize_for = 2;
+
+option java_package = "com.example.util"
+option java_outer_classname = "JavaOuterClassname"
+
+-- util.gunk.golden --
+// +gunk file.OptimizeFor(2)
+// +gunk java.Package("com.example.util")
+// +gunk java.OuterClassname("JavaOuterClassname")
+package util
+
+import (
+	"github.com/gunk/opt/file"
+	"github.com/gunk/opt/file/java"
+)

--- a/testdata/scripts/convert_files_and_folders.txt
+++ b/testdata/scripts/convert_files_and_folders.txt
@@ -20,11 +20,6 @@ enum status {
 -- util.gunk.golden --
 package util
 
-import (
-	"github.com/gunk/opt"
-	"github.com/gunk/opt/http"
-)
-
 type status int
 
 const (
@@ -49,11 +44,6 @@ enum status {
 
 -- util/util2.gunk.golden --
 package util
-
-import (
-	"github.com/gunk/opt"
-	"github.com/gunk/opt/http"
-)
 
 type status int
 

--- a/testdata/scripts/convert_iota.txt
+++ b/testdata/scripts/convert_iota.txt
@@ -22,11 +22,6 @@ enum Status {
 -- util.gunk.golden --
 package util
 
-import (
-	"github.com/gunk/opt"
-	"github.com/gunk/opt/http"
-)
-
 type Status int
 
 const (
@@ -50,11 +45,6 @@ enum Status {
 
 -- util2.gunk.golden --
 package util
-
-import (
-	"github.com/gunk/opt"
-	"github.com/gunk/opt/http"
-)
 
 type Status int
 


### PR DESCRIPTION
Updated convert to convert proto 'FileOptions' to the corresponding Gunk
annotations.

While doing this, it was required to keep a record of which
imports of Gunk annotations are being used. Now we only output imports
that are actually in use, or no imports at all if there are no imports.

Updates #143