### PR TITLE
generate: don't include stdout when an exec errors

### DIFF
--- a/convert/convert.go
+++ b/convert/convert.go
@@ -561,7 +561,7 @@ func (b *builder) handleImports() string {
 	b.format(w, 0, nil, "import (")
 
 	// Imports that have been used during convert
-	for i, _ := range b.importsUsed {
+	for i := range b.importsUsed {
 		b.format(w, 0, nil, "\n")
 		b.format(w, 1, nil, fmt.Sprintf("%q", i))
 	}

--- a/log/log.go
+++ b/log/log.go
@@ -2,12 +2,15 @@ package log
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
 )
 
 var (
+	Out io.Writer = os.Stderr
+
 	PrintCommands = false
 	Verbose       = false
 )
@@ -16,28 +19,28 @@ func Command(command string, args ...string) {
 	if !PrintCommands {
 		return
 	}
-	fmt.Printf("%s %s\n", command, strings.Join(args, " "))
+	fmt.Fprintf(Out, "%s %s\n", command, strings.Join(args, " "))
 }
 
 func Log(format string, args ...interface{}) {
 	if !Verbose {
 		return
 	}
-	fmt.Printf(format, args...)
+	fmt.Fprintf(Out, format, args...)
 }
 
 func PackageGenerated(pkgPath string) {
 	if !Verbose {
 		return
 	}
-	fmt.Println(pkgPath)
+	fmt.Fprintln(Out, pkgPath)
 }
 
 func ExecCommand(command string, args ...string) *exec.Cmd {
 	Command(command, args...)
 	cmd := exec.Command(command, args...)
 	if Verbose {
-		cmd.Stderr = os.Stdout
+		cmd.Stderr = Out
 	}
 	return cmd
 }

--- a/testdata/scripts/envs.txt
+++ b/testdata/scripts/envs.txt
@@ -7,17 +7,24 @@ exec chmod a+x bin/protoc
 # we should stop before any generators are run
 ! gunk generate .
 ! stdout .
-stderr 'exit status'
 stderr 'error executing "protoc"'
-! stderr 'error executing protoc-gen'
-! stderr panicc
+stderr 'exit status 34: fatal failure' # include stderr
+! stderr 'error executing protoc-gen' # we're not running any protoc-gen plugin
+! stderr 'some stdout' # stdout is likely uninteresting
+! stderr panic
+
+# in verbose mode, stderr was written out directly
+! gunk generate -v .
+stderr 'exit status 34$'
+stderr '^fatal failure$'
 
 -- bin/protoc --
 #!/bin/sh
 
+echo some stdout
 echo fatal failure >&2
 
-exit 1
+exit 34
 -- go.mod --
 module testdata.tld/util
 -- .gunkconfig --

--- a/testdata/scripts/generate_flags.txt
+++ b/testdata/scripts/generate_flags.txt
@@ -4,11 +4,11 @@ env PATH=$WORK/bin:$PATH
 exec chmod a+x bin/protoc
 
 gunk generate . -x
-stdout bin/protoc
+stderr bin/protoc
 
 gunk generate . -v
-stdout 'hello gunk'
-stdout testdata.tld/util
+stderr 'hello gunk'
+stderr testdata.tld/util
 
 -- bin/protoc --
 #!/bin/sh

--- a/testdata/scripts/generate_mappings.txt
+++ b/testdata/scripts/generate_mappings.txt
@@ -24,15 +24,15 @@ command=protoc-gen-go
 package mappings
 
 type Message struct {
-    Bool bool `pb:"1"`
+	Bool bool `pb:"1"`
 	String string `pb:"2"`
-    Int int `pb:"3"`
-    Int32 int32 `pb:"4"`
-    Uint uint `pb:"5"`
-    Uint32 uint32 `pb:"6"`
-    Int64 int64 `pb:"7"`
-    Uint64 uint64 `pb:"8"`
-    Float float32 `pb:"9"`
-    Double float64 `pb:"10"`
-    Slice []int `pb:"11"`
+	Int int `pb:"3"`
+	Int32 int32 `pb:"4"`
+	Uint uint `pb:"5"`
+	Uint32 uint32 `pb:"6"`
+	Int64 int64 `pb:"7"`
+	Uint64 uint64 `pb:"8"`
+	Float float32 `pb:"9"`
+	Double float64 `pb:"10"`
+	Slice []int `pb:"11"`
 }

--- a/testdata/scripts/generate_unused_imports.txt
+++ b/testdata/scripts/generate_unused_imports.txt
@@ -20,7 +20,7 @@ import (
 )
 
 type Code struct {
-    Code v2.Code `pb:"1"`
+	Code v2.Code `pb:"1"`
 }
 
 type Util interface {


### PR DESCRIPTION
Most programs, upon erroring, will only include the reason in stderr.
This led to some confusing error messages on common exec errors, such as
the binary missing in $PATH:

	error: error executing protoc-gen-print: , exec: "protoc-gen-print": executable file not found in $PATH

To fix this, don't include stdout in error messages. But do include
stderr if it wasn't already written out directly because of the verbose
flag.

Also make the log package output to os.Stderr by default, making it
configurable. Logging should generally go to stderr, as stdout is
reserved for the result or output of a program or command. This also
means that a plugin's stderr will always go to stderr if it errors, even
if gunk is run in verbose mode.

Finally, clean up the scripts files to not mix tabs and spaces
unnecessarily.