### PR TITLE
generate: refactor how we sort proto files

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -33,7 +33,9 @@ func TestMain(m *testing.M) {
 		cmd := exec.Command("go", "install", "-ldflags=-w -s",
 			"github.com/golang/protobuf/protoc-gen-go",
 			"github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway",
+			"./testdata/protoc-gen-strict",
 		)
+		cmd.Stderr = os.Stderr
 		if err := cmd.Run(); err != nil {
 			panic(err)
 		}

--- a/testdata/protoc-gen-strict/main.go
+++ b/testdata/protoc-gen-strict/main.go
@@ -1,0 +1,49 @@
+// protoc-gen-strict is like a protoc-gen-* program, but it just runs a number
+// of sanity checks on the CodeGeneratorRequest. It outputs an empty
+// CodeGeneratorResponse to stdout, to signal that there's nothing to generate.
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/golang/protobuf/proto"
+	desc "github.com/golang/protobuf/protoc-gen-go/descriptor"
+	plugin "github.com/golang/protobuf/protoc-gen-go/plugin"
+)
+
+func main() {
+	input, err := ioutil.ReadAll(os.Stdin)
+	if err != nil {
+		panic(err)
+	}
+	var req plugin.CodeGeneratorRequest
+	if err := proto.Unmarshal(input, &req); err != nil {
+		panic(err)
+	}
+	if err := check(&req); err != nil {
+		panic(err)
+	}
+	var resp plugin.CodeGeneratorResponse
+	output, err := proto.Marshal(&resp)
+	if err != nil {
+		panic(err)
+	}
+	if _, err := os.Stdout.Write(output); err != nil {
+		panic(err)
+	}
+}
+
+func check(req *plugin.CodeGeneratorRequest) error {
+	seenFiles := make(map[string]*desc.FileDescriptorProto)
+	for _, pfile := range req.ProtoFile {
+		for _, dep := range pfile.Dependency {
+			if seenFiles[dep] == nil {
+				return fmt.Errorf("%s has unknown dep %s", *pfile.Name, dep)
+			}
+		}
+		seenFiles[*pfile.Name] = pfile
+	}
+	return nil
+}

--- a/testdata/scripts/generate_fileorder.txt
+++ b/testdata/scripts/generate_fileorder.txt
@@ -1,0 +1,40 @@
+env HOME=$WORK/home
+
+gunk generate -v .
+
+-- go.mod --
+module testdata.tld/util
+-- .gunkconfig --
+[generate]
+command=protoc-gen-strict
+-- echo.gunk --
+package util // proto "testdata.v1.util"
+
+import (
+	"time"
+
+	"testdata.tld/util/p1"
+	"testdata.tld/util/p2"
+)
+
+type Message struct {
+	Time time.Time `pb:"1"`
+}
+
+type Util interface {
+	Echo() Message
+
+	UseImports(p2.Foo) p1.Bar
+}
+-- p2/foo.gunk --
+package p2
+
+type Foo struct {
+	Field string `pb:"1"`
+}
+-- p1/bar.gunk --
+package p1
+
+type Bar struct {
+	Field string `pb:"1"`
+}


### PR DESCRIPTION
First, add a test script that uses a custom Go generator which checks
that the ProtoFile slice is sorted topologically. We've found in the
past that some generators require that, so the easiest way to add a
regression test is to implement a dummy generator which checks that
property.

Second, redo the topological sort to support all inputs. The old code
only split the list of files in two chunks, which may quickly break if
one has multiple levels of package dependencies.

There are efficient algorithms we could have chosen which would have
taken over fifty lines of code, but a much simpler quadratic algorithm
will do the job for the foreseeable future in under twenty.

Finally, remove the sorts of files by name. We no longer have multiple
proto files per Gunk package, so we don't care about the order of
FileToGenerate. And ProtoFile is sorted topologically, so the name
sorting was useless.