### PR TITLE
convert: include filename in errors

### DIFF
--- a/testdata/scripts/convert_errors.txt
+++ b/testdata/scripts/convert_errors.txt
@@ -1,0 +1,11 @@
+env HOME=$WORK/home
+
+! gunk convert util.proto
+stderr 'error: util.proto:5:1: "hello" is an unhandled proto file option'
+
+-- util.proto --
+syntax = "proto3";
+
+package util;
+
+option hello = "world";


### PR DESCRIPTION
Add the filename to error messages in gunk convert. This is now required
because gunk convert can handle more than a single proto file.

Change the pkgOpts to use proto.Option rather than a custom struct so
that we don't lose positional information about an option, and can error
correctly on that options.

Fixes #154