### PR TITLE
convert: warn on unhandled proto options

### DIFF
--- a/testdata/scripts/convert_unhandled_options.txt
+++ b/testdata/scripts/convert_unhandled_options.txt
@@ -1,0 +1,34 @@
+env HOME=$WORK/home
+
+gunk convert util.proto
+stderr 'unhandled enum option "allow_alias"'
+stderr 'unhandled enumvalue option "deprecated"'
+stderr 'unhandled message option "message_set_wire_format"'
+stderr 'unhandled field option "lazy"'
+stderr 'unhandled service option "deprecated"'
+stderr 'unhandled method option "idempotency_level"'
+
+-- util.proto --
+syntax = "proto3";
+
+package util;
+
+enum Status {
+    option allow_alias = true;
+    NoStatus = 0;
+    Success = 1;
+    SuccessOld = 2 [deprecated = true];
+    Error = 3;
+}
+
+message Msg {
+    option message_set_wire_format = true;
+    string value = 1 [lazy = true];
+}
+
+service MsgService {
+    option deprecated = true;
+    rpc Echo(Msg) returns (Msg) {
+        option idempotency_level = 1;
+    }
+}


### PR DESCRIPTION
Print warnings for unhandled proto options when using gunk convert:

- message options
- field options
- enum options
- enumvalue options
- service options
- method options

This should only be temporary until we handle the missing proto options,
but this should at least give the user some warning that some of the
proto options they are using won't be converted.

Don't include newline in error message for gunk convert.

Updates #143