### PR TITLE
convert: remove unwanted new lines from interface methods

### DIFF
--- a/convert/convert.go
+++ b/convert/convert.go
@@ -376,8 +376,11 @@ func (b *builder) handleService(s *proto.Service) error {
 		if !ok {
 			return b.formatError(s.Position, "unexpected type %T in service, expected rpc", e)
 		}
-		// Add a newline between each new function declaration on the interface.
-		if i > 0 {
+		// Add a newline between each new function declaration on the interface, only
+		// if there is comments or gunk annotations seperating them. We can assume that
+		// anything in `Elements` will be a gunk annotation, otherwise an error is
+		// returned below.
+		if i > 0 && (r.Comment != nil || len(r.Elements) > 0) {
 			b.format(w, 0, nil, "\n")
 		}
 		// The comment to translate. It is possible that when we write

--- a/testdata/scripts/convert.txt
+++ b/testdata/scripts/convert.txt
@@ -25,6 +25,7 @@ message Msg {
 
 service MsgService {
     rpc Echo(Msg) returns (Msg) {}
+    // Handle handles a msg
     rpc Handle(Msg) returns (google.protobuf.Empty) {}
     rpc Result(google.protobuf.Empty) returns (Msg) {}
 }
@@ -69,8 +70,8 @@ type Msg struct {
 type MsgService interface {
 	Echo(Msg) Msg
 
+	// Handle handles a msg
 	Handle(Msg)
-
 	Result() Msg
 }
 


### PR DESCRIPTION
If there is a comment or gunk annotations above a gunk interface method,
add a newline before the comment or gunk annotation. This makes is a
little bit cleaner.

Fixes #149