### PR TITLE
generate: discard empty doc comments

### DIFF
--- a/generate/generate.go
+++ b/generate/generate.go
@@ -969,9 +969,20 @@ func (g *Generator) convertEnum(tspec *ast.TypeSpec) (*desc.EnumDescriptorProto,
 			if g.curPkg.TypesInfo.TypeOf(name) != enumType {
 				continue
 			}
-			// SomeVal will be exported as SomeType_SomeVal
-			docText := tspec.Name.Name + "_" + vs.Doc.Text()
-			g.addDoc(docText, enumPath, g.enumIndex, enumValuePath, int32(i))
+			docText := vs.Doc.Text()
+			switch {
+			case docText == "":
+				// The original comment only had gunk tags, and
+				// no actual documentation for us to keep.
+			case strings.HasPrefix(docText, name.Name):
+				// SomeVal will be exported as SomeType_SomeVal
+				docText = tspec.Name.Name + "_" + vs.Doc.Text()
+				fallthrough
+			default:
+				g.addDoc(docText, enumPath, g.enumIndex,
+					enumValuePath, int32(i))
+			}
+
 			val := g.curPkg.TypesInfo.Defs[name].(*types.Const).Val()
 			ival, _ := constant.Int64Val(val)
 			enumValueOptions, err := g.enumValueOptions(vs)

--- a/testdata/scripts/generate_enum.txt
+++ b/testdata/scripts/generate_enum.txt
@@ -1,0 +1,35 @@
+env HOME=$WORK/home
+
+gunk generate .
+! stdout .
+
+exists all.pb.go
+! grep '// Foo_$' all.pb.go # adding prefix to otherwise empty docs
+grep '// Foo_Documented is' all.pb.go
+grep '// this comment does not contain' all.pb.go
+
+-- go.mod --
+module testdata.tld/util
+
+require (
+	github.com/gunk/opt v0.0.0-20181129161359-767b03a66301
+)
+-- .gunkconfig --
+[generate]
+command=protoc-gen-go
+-- echo.gunk --
+package util
+
+import "github.com/gunk/opt/enumvalues"
+
+type Foo int
+
+const (
+	// Documented is documented.
+	Documented Foo = iota
+	// this comment does not contain the type name.
+	BadComment
+	// +gunk enumvalues.Deprecated(true)
+	OnlyTag
+	NoComment
+)

--- a/testdata/scripts/generate_options.txt
+++ b/testdata/scripts/generate_options.txt
@@ -14,7 +14,7 @@ grep 'string Msg = 1 \[ctype = STRING, deprecated = true, lazy = false, jstype =
 
 grep 'all.proto is a deprecated file' deprecated/all.pb.go
 grep 'type Status int32 // Deprecated: Do not use.' deprecated/all.pb.go
-grep 'Status_Error Status = 2 // Deprecated: Do not use.' deprecated/all.pb.go
+grep 'Status_Error *Status = 2 *// Deprecated: Do not use.' deprecated/all.pb.go
 grep 'Msg .* // Deprecated: Do not use.' deprecated/all.pb.go
 
 -- go.mod --


### PR DESCRIPTION
If a gunk comment only contained a gunk tag, don't keep it around as a
documentation comment in the generated code.

Add a test, and update generate_options.txt to be more permissive with
the whitespace. Since we removed a few bad comments there, gofmt now
aligns the field types, so a few spaces have been introduced.

Fixes #110.