### PR TITLE
generate: send 'nil' rather than empty string to protoc generators

### DIFF
--- a/generate/generate.go
+++ b/generate/generate.go
@@ -313,7 +313,11 @@ func execError(command string, err error) error {
 }
 
 func (g *Generator) generatePlugin(req plugin.CodeGeneratorRequest, gen config.Generator) error {
-	req.Parameter = proto.String(gen.ParamString())
+	// Due to problems with some generators (grpc-gateway),
+	// we need to ensure we either send a non-empty string or nil.
+	if ps := gen.ParamString(); ps != "" {
+		req.Parameter = proto.String(gen.ParamString())
+	}
 	bs, err := proto.Marshal(&req)
 	if err != nil {
 		return err

--- a/go.mod
+++ b/go.mod
@@ -12,9 +12,11 @@ require (
 	github.com/knq/snaker v0.0.0-20181215144011-2bc8a4db4687
 	github.com/rogpeppe/go-internal v1.1.0
 	github.com/stretchr/testify v1.3.0 // indirect
+	golang.org/x/net v0.0.0-20181106065722-10aee1819953
 	golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 // indirect
 	golang.org/x/tools v0.0.0-20190118193359-16909d206f00
 	google.golang.org/genproto v0.0.0-20190111180523-db91494dd46c
+	google.golang.org/grpc v1.16.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/yaml.v2 v2.2.2 // indirect
 )

--- a/testdata/generate/.gunkconfig
+++ b/testdata/generate/.gunkconfig
@@ -4,4 +4,3 @@ plugins=grpc
 
 [generate]
 command=protoc-gen-grpc-gateway
-logtostderr=true


### PR DESCRIPTION
We are sending an empty string to protoc generators for the 'Parameter'.
This was causing issues with 'protoc-gen-grpc-gateway'. We now send
'nil' when there is no parameters found in the config for a generator.

Fixes #165