### PR TITLE
generate: add positional information to errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,13 +8,16 @@ require (
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/golang/protobuf v1.2.0
 	github.com/grpc-ecosystem/grpc-gateway v1.6.4
+	github.com/gunk/opt v0.0.0-20190118082020-1439f71a8644 // indirect
 	github.com/knq/ini v0.0.0-20181118015158-a301e724bd35
 	github.com/knq/snaker v0.0.0-20181215144011-2bc8a4db4687
 	github.com/rogpeppe/go-internal v1.1.0
 	github.com/stretchr/testify v1.3.0 // indirect
+	golang.org/x/net v0.0.0-20181106065722-10aee1819953
 	golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 // indirect
 	golang.org/x/tools v0.0.0-20190118193359-16909d206f00
 	google.golang.org/genproto v0.0.0-20190111180523-db91494dd46c
+	google.golang.org/grpc v1.16.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/yaml.v2 v2.2.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/grpc-ecosystem/grpc-gateway v1.6.4 h1:xlu6C2WU6gvXt3XLyVpsgweaIL4VCmTjEsEAIt7qFqQ=
 github.com/grpc-ecosystem/grpc-gateway v1.6.4/go.mod h1:RSKVYQBd5MCa4OVpNdGskqpgL2+G+NZTnrVHpWWfpdw=
+github.com/gunk/opt v0.0.0-20190118082020-1439f71a8644 h1:16Cq50c+bi4n4qRyjsExt4WwULdMppYi8HpURssnnQQ=
+github.com/gunk/opt v0.0.0-20190118082020-1439f71a8644/go.mod h1:mwnDF6IXLCA4xXLUMmG7usTLB6Mk+KGQelNF1u390gc=
 github.com/kisielk/gotool v1.0.0 h1:AV2c/EiW3KqPNT9ZKl07ehoAGi4C5/01Cfbblndcapg=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/knq/ini v0.0.0-20181118015158-a301e724bd35 h1:et/xKFFaPqT7bV8MOn5KVnNiqenWdE9KM8fPlni6z0g=

--- a/testdata/scripts/generate_errors.txt
+++ b/testdata/scripts/generate_errors.txt
@@ -1,0 +1,23 @@
+env HOME=$WORK/home
+
+! gunk generate ./message_invalid
+stderr 'message_invalid/foo.gunk:4:5: missing required tag on InValid'
+
+! gunk generate ./service_invalid
+stderr 'service_invalid/foo.gunk:5:5: multiple parameters are not supported'
+
+-- .gunkconfig --
+[generate go]
+-- message_invalid/foo.gunk --
+package util
+
+type Message struct {
+    InValid bool
+}
+-- service_invalid/foo.gunk --
+package util
+
+type FooService interface {
+
+    Foo(int, string)
+}

--- a/testdata/scripts/repeated_function_param.txt
+++ b/testdata/scripts/repeated_function_param.txt
@@ -1,10 +1,10 @@
 env HOME=$WORK/home
 
 ! gunk generate ./p1
-stderr 'error: parameter type should not be repeated'
+stderr 'error: .*p1/p1.gunk:9:2: parameter type should not be repeated'
 
 ! gunk generate ./p2
-stderr 'error: parameter type should not be repeated'
+stderr 'error: .*p2/p2.gunk:9:2: parameter type should not be repeated'
 
 -- go.mod --
 module testdata.tld/util


### PR DESCRIPTION
Start recording the current position of the token being evaluated. We
then use the recorded position when priting out errors, so errors should
now include 'filename:line:column' at the start of all generate errors.

Fixes #169