### PR TITLE
loader: error on repeated sequence numbers

### DIFF
--- a/testdata/scripts/loader_repeated_sequence.txt
+++ b/testdata/scripts/loader_repeated_sequence.txt
@@ -1,0 +1,16 @@
+env HOME=$WORK/home
+
+! gunk format ./
+stderr 'sequence "1" on Text has already been used in this struct'
+stderr 'sequence "1" on Msg has already been used in this struct'
+
+-- go.mod --
+module testdata.tld/util
+-- echo.gunk --
+package util
+
+type Message struct {
+    Name string    `pb:"1" json:"name"`
+    Text string    `pb:"1" json:"text"`
+    Msg  string    `pb:"1" json:"msg"`
+}


### PR DESCRIPTION
If we detect the same sequence number used in a struct, return an error
pointing to the duplicated sequence number.

Fixes: #182