### PR TITLE
dump: add tests

### DIFF
--- a/dump/dump.go
+++ b/dump/dump.go
@@ -27,7 +27,7 @@ func Run(format, dir string, patterns ...string) error {
 		if err != nil {
 			return err
 		}
-	case "", "raw":
+	case "", "proto":
 		// The default format.
 		bs, err = proto.Marshal(fds)
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -28,9 +28,9 @@ var (
 	frmt         = app.Command("format", "Format Gunk code.")
 	frmtPatterns = frmt.Arg("patterns", "patterns of Gunk packages").Strings()
 
-	dmp         = app.Command("dump", "Write a FileDescriptorSet (a protocol buffer, defined in descriptor.proto)")
+	dmp         = app.Command("dump", "Write a FileDescriptorSet, defined in descriptor.proto")
 	dmpPatterns = dmp.Arg("patterns", "patterns of Gunk packages").Strings()
-	dmpFormat   = dmp.Flag("format", "output format to write FileDescriptorSet as (options are 'raw' or 'json'").String()
+	dmpFormat   = dmp.Flag("format", "output format: proto (default), or json").String()
 
 	ver = app.Command("version", "Show Gunk version.")
 )

--- a/testdata/scripts/dump.txt
+++ b/testdata/scripts/dump.txt
@@ -1,0 +1,22 @@
+env HOME=$WORK/home
+
+! gunk dump --format xxx
+! stdout .
+stderr 'unknown output format'
+
+gunk dump --format=json
+stdout '^{' # json
+stdout 'SomeMessage'
+
+gunk dump
+! stdout '^{' # the default format is proto
+stdout 'SomeMessage'
+
+-- go.mod --
+module testdata.tld/util
+-- normal.gunk --
+package util
+
+type SomeMessage struct {
+	Text string `pb:"1"`
+}


### PR DESCRIPTION
While at it, rename "raw" to "proto", since that's more descriptive of
what the actual format is. After all, we use proto.Marshal.

Finally, make dump's usage lines a bit better.

Fixes #174.