### PR TITLE
convert: actually use gunk's format.Source

### DIFF
--- a/convert/convert.go
+++ b/convert/convert.go
@@ -2,7 +2,6 @@ package convert
 
 import (
 	"fmt"
-	"go/format"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -11,6 +10,8 @@ import (
 
 	"github.com/emicklei/proto"
 	"github.com/knq/snaker"
+
+	"github.com/gunk/gunk/format"
 )
 
 type builder struct {
@@ -466,10 +467,10 @@ func (b *builder) handleService(s *proto.Service) error {
 						comment = nil
 					}
 					b.format(w, 1, nil, "// +gunk http.Match{\n")
-					b.format(w, 1, nil, "//     Method: %q,\n", strings.ToUpper(method))
-					b.format(w, 1, nil, "//     Path: %q,\n", url)
+					b.format(w, 1, nil, "// Method: %q,\n", strings.ToUpper(method))
+					b.format(w, 1, nil, "// Path: %q,\n", url)
 					if body != "" {
-						b.format(w, 1, nil, "//     Body: %q,\n", body)
+						b.format(w, 1, nil, "// Body: %q,\n", body)
 					}
 					b.format(w, 1, nil, "// }\n")
 					b.importsUsed["github.com/gunk/opt/http"] = true

--- a/testdata/scripts/convert.txt
+++ b/testdata/scripts/convert.txt
@@ -77,15 +77,15 @@ type MsgService interface {
 
 type HttpService interface {
 	// +gunk http.Match{
-	//     Method: "GET",
-	//     Path: "/v1/util",
+	//         Method: "GET",
+	//         Path:   "/v1/util",
 	// }
 	Get(Msg) Msg
 
 	// +gunk http.Match{
-	//     Method: "POST",
-	//     Path: "/v1/util",
-	//     Body: "*",
+	//         Method: "POST",
+	//         Path:   "/v1/util",
+	//         Body:   "*",
 	// }
 	Post(Msg)
 }


### PR DESCRIPTION
Due to human error, convert was only using go/format.Source, which does
less work than gunk's format. In particular, it doesn't format gunk
tags, which are behind Go comments.

Fix that, and add a proper test. The convert code no longer needs to
pretend to format gunk tags itself, as they get formatted anyway.