### PR TITLE
log: simplify package

### DIFF
--- a/generate/download.go
+++ b/generate/download.go
@@ -53,7 +53,7 @@ func checkOrDownloadProtoc() (string, error) {
 	if err := downloadAndExtractProtoc(protocCachePath); err != nil {
 		return "", err
 	}
-	log.DownloadedProtoc(protocCachePath)
+	log.Verbosef("downloaded protoc to %s", protocCachePath)
 	return protocCachePath, nil
 }
 

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -81,8 +81,7 @@ func Run(dir string, args ...string) error {
 		if err := g.GeneratePkg(pkg.PkgPath, cfg.Generators, protocPath); err != nil {
 			return err
 		}
-		log.PackageGenerated(pkg.PkgPath)
-
+		log.Verbosef("%s", pkg.PkgPath)
 	}
 	return nil
 }

--- a/log/log.go
+++ b/log/log.go
@@ -15,39 +15,26 @@ var (
 	Verbose       = false
 )
 
-func Command(command string, args ...string) {
-	if !PrintCommands {
-		return
-	}
-	fmt.Fprintf(Out, "%s %s\n", command, strings.Join(args, " "))
-}
-
-func Log(format string, args ...interface{}) {
-	if !Verbose {
-		return
+func Printf(format string, args ...interface{}) {
+	if !strings.HasSuffix(format, "\n") {
+		format += "\n"
 	}
 	fmt.Fprintf(Out, format, args...)
 }
 
-func PackageGenerated(pkgPath string) {
-	if !Verbose {
-		return
+func Verbosef(format string, args ...interface{}) {
+	if Verbose {
+		Printf(format, args...)
 	}
-	fmt.Fprintln(Out, pkgPath)
 }
 
 func ExecCommand(command string, args ...string) *exec.Cmd {
-	Command(command, args...)
+	if PrintCommands {
+		Printf("%s %s", command, strings.Join(args, " "))
+	}
 	cmd := exec.Command(command, args...)
 	if Verbose {
 		cmd.Stderr = Out
 	}
 	return cmd
-}
-
-func DownloadedProtoc(downloadPath string) {
-	if !Verbose {
-		return
-	}
-	fmt.Fprintf(Out, "downloaded protoc to %s\n", downloadPath)
 }


### PR DESCRIPTION
The log package only needs to care about printing lines, and whether
some lines are verbose or not. We also have a wrapper for exec.Cmd which
is handy. Everything else is redundant.

This can be shown by how halving the number of APIs in the log package
doesn't make the rest of the code any more complex. If anything, the
code using the log package is now simpler to follow.