### PR TITLE
loader: rethink package loading errors

### DIFF
--- a/format/format.go
+++ b/format/format.go
@@ -26,6 +26,9 @@ func Run(dir string, args ...string) error {
 	if len(pkgs) == 0 {
 		return fmt.Errorf("no Gunk packages to format")
 	}
+	if loader.PrintErrors(pkgs) > 0 {
+		return fmt.Errorf("encountered package loading errors")
+	}
 	for _, pkg := range pkgs {
 		for i, file := range pkg.GunkSyntax {
 			path := pkg.GunkFiles[i]

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -51,6 +51,9 @@ func Run(dir string, args ...string) error {
 	if len(pkgs) == 0 {
 		return fmt.Errorf("no Gunk packages to generate")
 	}
+	if loader.PrintErrors(pkgs) > 0 {
+		return fmt.Errorf("encountered package loading errors")
+	}
 
 	// Record the loaded packages in gunkPkgs.
 	g.recordPkgs(pkgs...)
@@ -91,6 +94,7 @@ func Run(dir string, args ...string) error {
 //
 // Currently, we only generate a FileDescriptorSet for one Gunk package.
 func FileDescriptorSet(dir string, args ...string) (*desc.FileDescriptorSet, error) {
+	// TODO: share code with Run; much of this function is identical.
 	g := &Generator{
 		Loader: loader.Loader{
 			Dir:   dir,
@@ -108,6 +112,9 @@ func FileDescriptorSet(dir string, args ...string) (*desc.FileDescriptorSet, err
 	}
 	if len(pkgs) != 1 {
 		return nil, fmt.Errorf("can only get filedescriptorset for a single Gunk package")
+	}
+	if loader.PrintErrors(pkgs) > 0 {
+		return nil, fmt.Errorf("encountered package loading errors")
 	}
 
 	// Record the loaded packages in gunkPkgs.

--- a/loader/visit.go
+++ b/loader/visit.go
@@ -1,0 +1,59 @@
+package loader
+
+import (
+	"fmt"
+	"os"
+	"sort"
+)
+
+// This file is an almost exact copy of go/packages/visit.go, but changed to
+// work on Gunk packages.
+
+// Visit visits all the packages in the import graph whose roots are
+// pkgs, calling the optional pre function the first time each package
+// is encountered (preorder), and the optional post function after a
+// package's dependencies have been visited (postorder).
+// The boolean result of pre(pkg) determines whether
+// the imports of package pkg are visited.
+func Visit(pkgs []*GunkPackage, pre func(*GunkPackage) bool, post func(*GunkPackage)) {
+	seen := make(map[*GunkPackage]bool)
+	var visit func(*GunkPackage)
+	visit = func(pkg *GunkPackage) {
+		if seen[pkg] {
+			return
+		}
+		seen[pkg] = true
+
+		if pre == nil || pre(pkg) {
+			paths := make([]string, 0, len(pkg.Imports))
+			for path := range pkg.Imports {
+				paths = append(paths, path)
+			}
+			sort.Strings(paths) // Imports is a map, this makes visit stable
+			for _, path := range paths {
+				visit(pkg.Imports[path])
+			}
+		}
+
+		if post != nil {
+			post(pkg)
+		}
+	}
+	for _, pkg := range pkgs {
+		visit(pkg)
+	}
+}
+
+// PrintErrors prints to os.Stderr the accumulated errors of all
+// packages in the import graph rooted at pkgs, dependencies first.
+// PrintErrors returns the number of errors printed.
+func PrintErrors(pkgs []*GunkPackage) int {
+	var n int
+	Visit(pkgs, nil, func(pkg *GunkPackage) {
+		for _, err := range pkg.Errors {
+			fmt.Fprintln(os.Stderr, err)
+			n++
+		}
+	})
+	return n
+}

--- a/testdata/scripts/dump.txt
+++ b/testdata/scripts/dump.txt
@@ -12,6 +12,10 @@ gunk dump
 ! stdout '^{' # the default format is proto
 stdout 'SomeMessage'
 
+! gunk dump ./badsyntax
+stderr 'expected .}., found .EOF.'
+! stdout .
+
 -- go.mod --
 module testdata.tld/util
 -- normal.gunk --
@@ -20,3 +24,7 @@ package util
 type SomeMessage struct {
 	Text string `pb:"1"`
 }
+-- badsyntax/badsyntax.gunk --
+package util
+
+type SomeMessage struct {

--- a/testdata/scripts/loader_typeerror.txt
+++ b/testdata/scripts/loader_typeerror.txt
@@ -1,0 +1,25 @@
+env HOME=$WORK/home
+
+! gunk format ./...
+stderr 'expected .}., found .EOF.'
+! stderr 'undeclared name: MissingType' # no typechecking
+stderr 'package loading errors'
+
+! gunk generate ./...
+stderr 'expected .}., found .EOF.'
+stderr 'undeclared name: MissingType'
+stderr 'package loading errors'
+
+-- go.mod --
+module testdata.tld/util
+-- p1/parseerror.gunk --
+package p1
+
+type Message struct {
+	Field int `pb:"1"`
+-- p2/typeerror.gunk --
+package p1
+
+type Message struct {
+	Field MissingType `pb:"1"`
+}


### PR DESCRIPTION
go/packages only uses its error return for fatal errors, such as when
the query is malformed or when it cannot call 'go list'.

All other errors, such as typecheck errors, are attached to packages.
This is because loading can often continue in the face of these
non-fatal errors, and it's useful for tools to report many errors at
once.

Do the same in our loader package. On the upside, this removes
ValidateError, removes a few error returns, and consolidates the API
with go/packages.

The only disadvantage is that we now need to port PrintErrors from
go/packages, which also requires Visit. But it's likely we were going to
need Visit sooner or later, anyway.