### PR TITLE
download: gunk download command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,20 +9,8 @@ go:
 env:
   - GO111MODULE=on
 
-addons:
-  apt:
-    packages:
-      - unzip
-
-before_install:
-  - mkdir -p $PWD/protoc /tmp/protobuf
-  - wget -O $PWD/protoc/protoc https://repo1.maven.org/maven2/com/google/protobuf/protoc/3.6.1/protoc-3.6.1-linux-x86_64.exe
-  - wget -O /tmp/protobuf/protobuf.jar https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.6.1/protobuf-java-3.6.1.jar
-  - unzip -qq /tmp/protobuf/protobuf.jar -d /tmp/protobuf && mv /tmp/protobuf/google $PWD
-  - chmod +x $PWD/protoc/protoc
-  - export PATH=$PWD/protoc/:$PATH
-
 install: true
 
 script:
+  - go run main.go download
   - go test -coverprofile=cover.out -v ./...

--- a/generate/download.go
+++ b/generate/download.go
@@ -20,10 +20,10 @@ const (
 	protocURL = "https://github.com/protocolbuffers/protobuf/releases/download/v%s/protoc-%s-%s.zip"
 )
 
-// checkOrDownloadProtoc will check the $PATH for 'protoc', if it doesn't
+// CheckOrDownloadProtoc will check the $PATH for 'protoc', if it doesn't
 // exist it checks to see if it has previously been downloaded to the
 // gunk cache, if not download protoc.
-func checkOrDownloadProtoc() (string, error) {
+func CheckOrDownloadProtoc() (string, error) {
 	// First check $PATH for protoc
 	if path, err := exec.LookPath("protoc"); err == nil && path != "" {
 		return path, nil

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -39,7 +39,7 @@ func Run(dir string, args ...string) error {
 	}
 
 	// Check that protoc exists, if not download it.
-	protocPath, err := checkOrDownloadProtoc()
+	protocPath, err := CheckOrDownloadProtoc()
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -32,6 +32,8 @@ var (
 	dmpPatterns = dmp.Arg("patterns", "patterns of Gunk packages").Strings()
 	dmpFormat   = dmp.Flag("format", "output format: proto (default), or json").String()
 
+	download = app.Command("download", "Download required tools for Gunk, e.g., protoc")
+
 	ver = app.Command("version", "Show Gunk version.")
 )
 
@@ -54,6 +56,8 @@ func main1() (code int) {
 	gen.Flag("print-commands", "print the commands").Short('x').BoolVar(&log.PrintCommands)
 	gen.Flag("verbose", "print the names of packages as they are generated").Short('v').BoolVar(&log.Verbose)
 
+	download.Flag("verbose", "print details of downloaded tools").Short('v').BoolVar(&log.Verbose)
+
 	command, err := app.Parse(os.Args[1:])
 	if terminated {
 		// simulate the os.Exit that would have happened
@@ -73,6 +77,8 @@ func main1() (code int) {
 		err = format.Run("", *frmtPatterns...)
 	case dmp.FullCommand():
 		err = dump.Run(*dmpFormat, "", *dmpPatterns...)
+	case download.FullCommand():
+		_, err = generate.CheckOrDownloadProtoc()
 	}
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)

--- a/testdata/scripts/download.txt
+++ b/testdata/scripts/download.txt
@@ -1,0 +1,14 @@
+env HOME=$WORK/home
+
+# Override the PATH so protoc isn't accessible.
+env PATH=$WORK/bin
+
+# Download protoc since it isn't on the PATH.
+gunk download -v
+! stdout .
+stderr 'downloaded protoc to'
+
+# This shouldn't download anything.
+gunk download -v
+! stdout .
+! stderr .


### PR DESCRIPTION
Added 'gunk download' command which will download any required, but
missing, tools or packages. Currently, this will only download protoc.

Added test for downloading protoc.

Changed CI to download protoc using 'gunk download'.

Fixes: #177
Fixes: #175