### PR TITLE
fix app.Terminate to properly terminate kingpin

### DIFF
--- a/testdata/scripts/cmds.txt
+++ b/testdata/scripts/cmds.txt
@@ -8,7 +8,7 @@ stdout '^gunk v0.*'
 ! stderr .
 
 gunk -h
-stderr '^usage: gunk \['
+stderr -count=1 '^usage: gunk \['
 ! stdout .
 
 gunk --help


### PR DESCRIPTION
For better or worse, kingpin's Terminate function needs to actually exit
kingpin's control flow. Since we can't use os.Exit because of
testscript, our only other option is a custom panic type.

One symptom of that bug was that 'gunk -h' displayed the help text twice
- once for the help flag, and a second time since no subcommand was
given.

Fix that, and add a regression test.