### PR TITLE
convert: error if package name isn't Go compatible

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/golang/protobuf/proto"
 	desc "github.com/golang/protobuf/protoc-gen-go/descriptor"
@@ -698,4 +699,18 @@ func ErrorAbsolutePos(err error, pos token.Position) error {
 		list[i] = err
 	}
 	return list
+}
+
+// IsIdentifier will return if the 'str' is a valid Go indentifier.
+func IsIdentifier(str string) bool {
+	if len(str) == 0 {
+		return false
+	}
+	for i, c := range str {
+		if unicode.IsLetter(c) || c == '_' || (i > 0 && unicode.IsDigit(c)) {
+			continue
+		}
+		return false
+	}
+	return true
 }

--- a/testdata/scripts/convert_invalid_package_name.txt
+++ b/testdata/scripts/convert_invalid_package_name.txt
@@ -1,0 +1,9 @@
+env HOME=$WORK/home
+
+! gunk convert util.proto
+stderr 'invalid character ''.'' in package name "v2.util"'
+
+-- util.proto --
+syntax = "proto3";
+
+package v2.util;


### PR DESCRIPTION
If the package name of the proto file being converted isn't a Go
compatible package name, e.g: contains a ".".

Updates #146