### PR TITLE
all: simplify type switches, remove IsIdentifier

### DIFF
--- a/format/format.go
+++ b/format/format.go
@@ -78,13 +78,13 @@ func formatFile(fset *token.FileSet, file *ast.File) (_ []byte, formatErr error)
 		}
 	}()
 	ast.Inspect(file, func(node ast.Node) bool {
-		switch node.(type) {
+		switch node := node.(type) {
 		case *ast.CommentGroup:
-			if err := formatComment(fset, node.(*ast.CommentGroup)); err != nil {
+			if err := formatComment(fset, node); err != nil {
 				panic(inspectError{err})
 			}
 		case *ast.StructType:
-			if err := formatStruct(fset, node.(*ast.StructType)); err != nil {
+			if err := formatStruct(fset, node); err != nil {
 				panic(inspectError{err})
 			}
 		}

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -20,7 +20,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-	"unicode"
 
 	"github.com/golang/protobuf/proto"
 	desc "github.com/golang/protobuf/protoc-gen-go/descriptor"
@@ -703,18 +702,4 @@ func ErrorAbsolutePos(err error, pos token.Position) error {
 		list[i] = err
 	}
 	return list
-}
-
-// IsIdentifier will return if the 'str' is a valid Go indentifier.
-func IsIdentifier(str string) bool {
-	if len(str) == 0 {
-		return false
-	}
-	for i, c := range str {
-		if unicode.IsLetter(c) || c == '_' || (i > 0 && unicode.IsDigit(c)) {
-			continue
-		}
-		return false
-	}
-	return true
 }


### PR DESCRIPTION
We can use an assignment in a type switch, so that we don't have to use
type assertions further down in each switch case.

And IsIdentifier was added by mistake.