### PR TITLE
loader: named imports and message options

### DIFF
--- a/testdata/scripts/convert_options.txt
+++ b/testdata/scripts/convert_options.txt
@@ -1,0 +1,37 @@
+env HOME=$WORK/home
+
+gunk convert util.proto
+cmp util.gunk util.gunk.golden
+
+-- util.proto --
+syntax = "proto3";
+
+package util;
+
+option optimize_for = 2;
+
+option cc_enable_arenas = true;
+
+message Msg {
+    string code = 1 [packed=true];
+    string type = 2 [cc_type="some_type"];
+}
+
+-- util.gunk.golden --
+// +gunk file.OptimizeFor(2)
+// +gunk filecc.EnableArenas(true)
+package util
+
+import (
+	"github.com/gunk/opt/file"
+	filecc "github.com/gunk/opt/file/cc"
+	"github.com/gunk/opt/message"
+	"github.com/gunk/opt/message/cc"
+)
+
+type Msg struct {
+	// +gunk message.Packed(true)
+	Code string `pb:"1" json:"code"`
+	// +gunk cc.Type("some_type")
+	Type string `pb:"2" json:"type"`
+}

--- a/testdata/scripts/convert_unhandled_options.txt
+++ b/testdata/scripts/convert_unhandled_options.txt
@@ -4,7 +4,6 @@ gunk convert util.proto
 stderr 'unhandled enum option "allow_alias"'
 stderr 'unhandled enumvalue option "deprecated"'
 stderr 'unhandled message option "message_set_wire_format"'
-stderr 'unhandled field option "lazy"'
 stderr 'unhandled service option "deprecated"'
 stderr 'unhandled method option "idempotency_level"'
 


### PR DESCRIPTION
When loading and converting a proto file to a gunk file, use named
imports for imports that are likely to have the same package name.

The first time an import is seen, that gets to keep its package name.
The next time an import with that package name is encounted, that
is given a named import.

Updates: #143