### PR TITLE
convert: handle nested message

### DIFF
--- a/generate/generate.go
+++ b/generate/generate.go
@@ -981,6 +981,10 @@ func (g *Generator) qualifiedTypeName(typeName string, pkg *types.Package) strin
 		return "." + g.curPkg.ProtoName + "." + typeName
 	}
 	gpkg := g.gunkPkgs[pkg.Path()]
+	// If ProtoName is empty, we are in the same package
+	if gpkg.ProtoName == "" {
+		return "." + typeName
+	}
 	return "." + gpkg.ProtoName + "." + typeName
 }
 

--- a/testdata/scripts/convert_nested_messages.txt
+++ b/testdata/scripts/convert_nested_messages.txt
@@ -1,0 +1,45 @@
+env HOME=$WORK/home
+
+gunk convert util.proto
+cmp util.gunk util.gunk.golden
+
+-- util.proto --
+syntax = "proto3";
+
+package util;
+
+message Event {
+	message Source {
+		string name = 1;
+		message Content {
+			string content = 1;
+		}
+		Content content = 2;
+	}
+	Source source = 1;
+	bool received = 2; 
+}
+
+message Message {
+	Event.Source source = 1;
+}
+-- util.gunk.golden --
+package util
+
+type Content struct {
+	Content string `pb:"1" json:"content"`
+}
+
+type Source struct {
+	Name    string  `pb:"1" json:"name"`
+	Content Content `pb:"2" json:"content"`
+}
+
+type Event struct {
+	Source   Source `pb:"1" json:"source"`
+	Received bool   `pb:"2" json:"received"`
+}
+
+type Message struct {
+	Source Source `pb:"1" json:"source"`
+}


### PR DESCRIPTION
Protocol buffer supports nested message, as described [here](https://developers.google.com/protocol-buffers/docs/proto3#nested)

This PR adds the support of nested message in gunk by: 
- adding a case for `proto.Message` type in `handleMessage` that calls itself
- remove `.` from the declaration type of a nested message referenced outside of its parent

Fix issue when generating from a `.gunk` with struct containing struct from the same package