### PR TITLE
convert: handle duplicate message

### DIFF
--- a/testdata/scripts/convert_duplicates.txt
+++ b/testdata/scripts/convert_duplicates.txt
@@ -1,0 +1,55 @@
+env HOME=$WORK/home
+
+gunk convert util.proto
+cmp util.gunk util.gunk.golden
+
+! gunk convert util2.proto
+stderr 'error: util2.proto:13:1: Event_Source redeclared in this block'
+
+-- util.proto --
+syntax = "proto3";
+
+package util;
+
+message Event {
+	message Source {
+		string name = 1;
+	}
+	Source source = 1;
+	bool received = 2; 
+}
+
+message Source {
+	string name = 1;
+}
+-- util.gunk.golden --
+package util
+
+type Event_Source struct {
+	Name string `pb:"1" json:"name"`
+}
+
+type Event struct {
+	Source   Event_Source `pb:"1" json:"source"`
+	Received bool         `pb:"2" json:"received"`
+}
+
+type Source struct {
+	Name string `pb:"1" json:"name"`
+}
+-- util2.proto --
+syntax = "proto3";
+
+package util;
+
+message Event {
+	message Source {
+		string name = 1;
+	}
+	Source source = 1;
+	bool received = 2; 
+}
+
+message Event_Source {
+	string name = 1;
+}

--- a/testdata/scripts/convert_nested_messages.txt
+++ b/testdata/scripts/convert_nested_messages.txt
@@ -26,20 +26,20 @@ message Message {
 -- util.gunk.golden --
 package util
 
-type Content struct {
+type Event_Source_Content struct {
 	Content string `pb:"1" json:"content"`
 }
 
-type Source struct {
-	Name    string  `pb:"1" json:"name"`
-	Content Content `pb:"2" json:"content"`
+type Event_Source struct {
+	Name    string               `pb:"1" json:"name"`
+	Content Event_Source_Content `pb:"2" json:"content"`
 }
 
 type Event struct {
-	Source   Source `pb:"1" json:"source"`
-	Received bool   `pb:"2" json:"received"`
+	Source   Event_Source `pb:"1" json:"source"`
+	Received bool         `pb:"2" json:"received"`
 }
 
 type Message struct {
-	Source Source `pb:"1" json:"source"`
+	Source Event_Source `pb:"1" json:"source"`
 }


### PR DESCRIPTION
- Ensure that there is no duplicate between nested and top-level message. 
- Rename nested message to `Parent_Child` instead of `Child` when creating the top level struct
