### PR TITLE
fix running some of the tests on Go 1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: go
 
 go:
   - 1.11.x
-  - 1.12rc1
+  - 1.12.x
 
 env:
   - GO111MODULE=on

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -66,6 +66,9 @@ func (l *Loader) addTempGoFiles() (undo func(), _ error) {
 	if out, err := cmd.Output(); err == nil {
 		root = strings.TrimSpace(string(out))
 	}
+	if root == "" {
+		return nil, fmt.Errorf("empty module root; missing module?")
+	}
 
 	var toDelete []string
 	if err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {

--- a/testdata/scripts/config_projectroot.txt
+++ b/testdata/scripts/config_projectroot.txt
@@ -11,15 +11,21 @@ exists gitfile/all.pb.go
 ! exists gitfile/all_pb2.py
 
 # Check that the project root is assumed to be where the go.mod file it.
-gunk generate ./gomod
-exists gomod/all.pb.go
-! exists gomod/all_pb2.py
+# The parent module can't see packages inside the child module, so cd into it.
+! gunk generate ./gomod
+stderr 'no Gunk packages to generate'
+
+cd gomod
+gunk generate .
+exists all.pb.go
+! exists all_pb2.py
 
 # Add a gunk config not in the project root.
 # This should not get picked up
+-- go.mod --
+module root
 -- .gunkconfig --
 [generate python]
-
 -- gitfolder/.git/config --
 -- gitfolder/.gunkconfig --
 [generate]
@@ -55,6 +61,7 @@ type Util interface {
 }
 
 -- gomod/go.mod --
+module testdata.tld/util
 -- gomod/.gunkconfig --
 [generate]
 command=protoc-gen-go

--- a/testdata/scripts/generate_errors.txt
+++ b/testdata/scripts/generate_errors.txt
@@ -6,6 +6,8 @@ stderr 'message_invalid/foo.gunk:4:5: missing required tag on InValid'
 ! gunk generate ./service_invalid
 stderr 'service_invalid/foo.gunk:5:5: multiple parameters are not supported'
 
+-- go.mod --
+module testdata.tld/util
 -- .gunkconfig --
 [generate go]
 -- message_invalid/foo.gunk --

--- a/testdata/scripts/generate_mappings.txt
+++ b/testdata/scripts/generate_mappings.txt
@@ -17,6 +17,8 @@ grep 'Float.*float32' all.pb.go
 grep 'Double.*float64' all.pb.go
 grep 'Slice.*\[\]int32' all.pb.go
 
+-- go.mod --
+module testdata.tld/util
 -- .gunkconfig --
 [generate]
 command=protoc-gen-go


### PR DESCRIPTION
Go 1.13 has GO111MODULE=on as a default, so some of the tests now
started failing. For example, config_projectroot.txt ran some 'go list'
commands with no go.mod file underneath, meaning that 1.12 was falling
back to GOPATH mode.

First, make those errors more obvious; before they used to be just:

	error: lstat : no such file or directory

This was because 'go list -m -f={{.Dir}}' would return an empty string,
so we'd try to filepath.Walk an empty path.

Second, add go.mod files where appropriate in the tests. Not having
these go.mod files was likely an oversight, as they are needed to
properly load packages in module mode.

Third, modify the 'gomod' test case, as it's not possible to load a
module's packages from another module via relative paths.