### PR TITLE
skip the download test script for now

### DIFF
--- a/testdata/scripts/download.txt
+++ b/testdata/scripts/download.txt
@@ -1,3 +1,5 @@
+skip 'TODO: rewrite to not require internet'
+
 env HOME=$WORK/home
 
 # Override the PATH so protoc isn't accessible.


### PR DESCRIPTION
Until we can rewrite it to not require internet and be faster. Speeds up
'go test' on my laptop from 4-8s to ~1s.