### PR TITLE
loader: set up Name and ProtoName when loading files

### DIFF
--- a/generate/generate.go
+++ b/generate/generate.go
@@ -981,10 +981,6 @@ func (g *Generator) qualifiedTypeName(typeName string, pkg *types.Package) strin
 		return "." + g.curPkg.ProtoName + "." + typeName
 	}
 	gpkg := g.gunkPkgs[pkg.Path()]
-	// If ProtoName is empty, we are in the same package
-	if gpkg.ProtoName == "" {
-		return "." + typeName
-	}
 	return "." + gpkg.ProtoName + "." + typeName
 }
 

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -155,7 +155,7 @@ func (l *Loader) Load(patterns ...string) ([]*GunkPackage, error) {
 		pkgs = append(pkgs, &GunkPackage{
 			Package: packages.Package{
 				ID:      "command-line-arguments",
-				Name:    "", // TODO?
+				Name:    "", // will be filled later
 				PkgPath: "command-line-arguments",
 			},
 			GunkFiles: patterns,
@@ -324,6 +324,13 @@ func (l *Loader) parseGunkPackage(pkg *GunkPackage) {
 		relPath := pkg.PkgPath + "/" + filepath.Base(fpath)
 		pkg.GunkNames = append(pkg.GunkNames, relPath)
 		pkg.GunkSyntax = append(pkg.GunkSyntax, file)
+
+		if name := file.Name.Name; pkg.Name == "" {
+			pkg.Name = name
+		} else if pkg.Name != name && l.Types {
+			pkg.addError(ValidateError, 0, nil, "gunk package name mismatch: %q %q",
+				pkg.Name, name)
+		}
 
 		name, err := protoPackageName(l.Fset, file)
 		if err != nil {

--- a/testdata/scripts/generate_nested_message.txt
+++ b/testdata/scripts/generate_nested_message.txt
@@ -1,0 +1,25 @@
+env HOME=$WORK/home
+
+gunk generate echo.gunk
+
+-- go.mod --
+module testdata.tld/util
+
+require (
+	github.com/gunk/opt v0.0.0-20181129161359-767b03a66301
+)
+-- .gunkconfig --
+[generate]
+command=protoc-gen-go
+-- echo.gunk --
+package util
+
+import "github.com/gunk/opt/enumvalues"
+
+type Message_Event struct {
+	Name string `pb:"1" json:"name"`
+}
+
+type Event struct {
+	Message Message_Event `pb:"1" json:"message"`
+}


### PR DESCRIPTION
We were leaving pkg.Name as a TODO when loading single files. And this
was usually fine, except when generating lone Gunk files under some
circumstances.

Cédric ran into one of those in the added test script, which he
supplied. Fix the bug in the loader by grabbing the package name from
all the files, much like cmd/go does.

Finally, remove the ProtoName=="" workaround that was added recently
because of this bug.