### PR TITLE
convert: handle import proto files

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,6 +478,31 @@ $ gunk convert /path/to/file.proto
 $ gunk convert /path/to/protobuf/directory
 ```
 
+If your `.proto` is referencing another `.proto` from another directory, 
+you can add `import_path` in the global section of your `.gunkconfig`.
+If you don't provide `import_path` it will only search in the root directory.
+
+
+```ini
+import_path=relative/path/to/protobuf/directory
+```
+
+> The path to provide is relative from the `.gunkconfig` location.
+
+Furthermore, the referenced files must contain:
+
+```proto
+option go_package="path/of/go/package";
+```
+
+The resulting `.gunk` file will contain the import path as defined in `go_package`:
+
+```go
+import (
+	name "path/of/go/package"
+)
+```
+
 ## About
 
 Gunk is developed by the team at [Brankas][brankas], and was designed to

--- a/config/config.go
+++ b/config/config.go
@@ -75,6 +75,7 @@ func (g Generator) OutPath(packageDir string) string {
 type Config struct {
 	Dir        string
 	Out        string
+	ImportPath string
 	Generators []Generator
 }
 
@@ -115,6 +116,7 @@ func Load(dir string) (*Config, error) {
 					cfg.Generators[i].Out = cfg.Out
 				}
 			}
+
 			cfgs = append(cfgs, cfg)
 		}
 
@@ -211,7 +213,9 @@ func load(reader io.Reader) (*Config, error) {
 		if err != nil {
 			return nil, err
 		}
-		config.Generators = append(config.Generators, *gen)
+		if gen != nil {
+			config.Generators = append(config.Generators, *gen)
+		}
 	}
 	return config, nil
 }
@@ -249,6 +253,8 @@ func handleGlobal(config *Config, section *parser.Section) error {
 		switch k {
 		case "out":
 			config.Out = v
+		case "import_path":
+			config.ImportPath = v
 		default:
 			return fmt.Errorf("unexpected key %q in global section", k)
 		}

--- a/convert/convert.go
+++ b/convert/convert.go
@@ -7,31 +7,48 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/gunk/gunk/config"
 	"github.com/gunk/gunk/format"
+	"github.com/gunk/gunk/generate"
 	"github.com/gunk/gunk/loader"
 )
 
 // Run converts proto files or folders to gunk files, saving the files in
 // the same folder as the proto file.
 func Run(paths []string, overwrite bool) error {
+	// Check that protoc exists, if not download it.
+	protocPath, err := generate.CheckOrDownloadProtoc()
+	if err != nil {
+		return err
+	}
+
 	for _, path := range paths {
-		if err := run(path, overwrite); err != nil {
+		if err := run(path, overwrite, protocPath); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func run(path string, overwrite bool) error {
+func run(path string, overwrite bool, protocPath string) error {
 
 	fi, err := os.Stat(path)
 	if err != nil {
 		return err
 	}
+
+	// Look for a .gunkconfig
+	absPath, _ := filepath.Abs(path)
+	cfg, err := config.Load(filepath.Dir(absPath))
+	var importPath string
+	if err == nil {
+		importPath = filepath.Join(cfg.Dir, cfg.ImportPath)
+	}
+
 	// Determine whether the path is a file or a directory.
 	// If it is a file convert the file.
 	if !fi.IsDir() {
-		return convertFile(path, overwrite)
+		return convertFile(path, overwrite, importPath, protocPath)
 	} else if filepath.Ext(path) == ".proto" {
 		// If the path is a directory and has a .proto extension then error.
 		return fmt.Errorf("%s is a directory, should be a proto file", path)
@@ -49,14 +66,14 @@ func run(path string, overwrite bool) error {
 		if f.IsDir() || filepath.Ext(f.Name()) != ".proto" {
 			continue
 		}
-		if err := convertFile(filepath.Join(path, f.Name()), overwrite); err != nil {
+		if err := convertFile(filepath.Join(path, f.Name()), overwrite, importPath, protocPath); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func convertFile(path string, overwrite bool) error {
+func convertFile(path string, overwrite bool, importPath string, protocPath string) error {
 	if filepath.Ext(path) != ".proto" {
 		return fmt.Errorf("convert requires a .proto file")
 	}
@@ -75,7 +92,7 @@ func convertFile(path string, overwrite bool) error {
 	}
 
 	w := &strings.Builder{}
-	if err := loader.ConvertFromProto(w, file, filename); err != nil {
+	if err := loader.ConvertFromProto(w, file, filename, importPath, protocPath); err != nil {
 		return err
 	}
 

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -37,6 +37,8 @@ func Run(dir string, args ...string) error {
 
 		gunkPkgs: make(map[string]*loader.GunkPackage),
 		allProto: make(map[string]*desc.FileDescriptorProto),
+
+		protoLoader: &loader.ProtoLoader{},
 	}
 
 	// Check that protoc exists, if not download it.
@@ -150,6 +152,10 @@ type Generator struct {
 
 	// Maps from package import path to package information.
 	gunkPkgs map[string]*loader.GunkPackage
+
+	// imported proto files will be loaded using protoLoader
+	// holds the absolute path passed to -I flag from protoc
+	protoLoader *loader.ProtoLoader
 
 	allProto map[string]*desc.FileDescriptorProto
 
@@ -1134,7 +1140,7 @@ func (g *Generator) loadProtoDeps() error {
 		}
 	}
 
-	files, err := loader.LoadProto(list...)
+	files, err := g.protoLoader.LoadProto(list...)
 	if err != nil {
 		return err
 	}

--- a/testdata/scripts/convert_files_and_folders.txt
+++ b/testdata/scripts/convert_files_and_folders.txt
@@ -1,4 +1,4 @@
-env home=$work/home
+env HOME=$WORK/home
 
 gunk convert util.proto ./util
 cmp util.gunk util.gunk.golden

--- a/testdata/scripts/convert_import.txt
+++ b/testdata/scripts/convert_import.txt
@@ -1,0 +1,48 @@
+env HOME=$WORK/home
+
+gunk convert util.proto
+cmp util.gunk util.gunk.golden
+
+-- .gunkconfig --
+
+-- util.proto --
+syntax = "proto3";
+
+package util;
+
+import "imported/imported.proto";
+
+message EventRequest {
+	string Name = 1;
+	imported.Type Type = 2;
+	message Nested {
+		string value = 1;
+	}
+	Nested nested = 3;
+}
+-- util.gunk.golden --
+package util
+
+import (
+	imported "github.com/gunk/gunk/imported"
+)
+
+type EventRequest_Nested struct {
+	Value string `pb:"1" json:"value"`
+}
+
+type EventRequest struct {
+	Name   string              `pb:"1" json:"name"`
+	Type   imported.Type       `pb:"2" json:"type"`
+	Nested EventRequest_Nested `pb:"3" json:"nested"`
+}
+-- imported/imported.proto --
+syntax = "proto3";
+
+package imported;
+
+option go_package= "github.com/gunk/gunk/imported";
+
+message Type {
+	string Name = 1;
+}

--- a/testdata/scripts/convert_import_missing_gopkg.txt
+++ b/testdata/scripts/convert_import_missing_gopkg.txt
@@ -1,0 +1,46 @@
+env HOME=$WORK/home
+
+! gunk convert util.proto
+stderr 'error: imported file must contain go_package option imported/imported.proto'
+
+-- .gunkconfig --
+
+-- util.proto --
+syntax = "proto3";
+
+package util;
+
+import "imported/imported.proto";
+
+message EventRequest {
+	string Name = 1;
+	imported.Type Type = 2;
+	message Nested {
+		string value = 1;
+	}
+	Nested nested = 3;
+}
+-- util.gunk.golden --
+package util
+
+import (
+	imported "github.com/gunk/gunk/imported"
+)
+
+type EventRequest_Nested struct {
+	Value string `pb:"1" json:"value"`
+}
+
+type EventRequest struct {
+	Name   string              `pb:"1" json:"name"`
+	Type   imported.Type       `pb:"2" json:"type"`
+	Nested EventRequest_Nested `pb:"3" json:"nested"`
+}
+-- imported/imported.proto --
+syntax = "proto3";
+
+package imported;
+
+message Type {
+	string Name = 1;
+}

--- a/testdata/scripts/convert_import_no_gunkconfig.txt
+++ b/testdata/scripts/convert_import_no_gunkconfig.txt
@@ -1,0 +1,46 @@
+env HOME=$WORK/home
+
+! gunk convert util.proto
+stderr 'error: util.proto:9:2: imported.Type is undefined'
+
+-- util.proto --
+syntax = "proto3";
+
+package util;
+
+import "imported/imported.proto";
+
+message EventRequest {
+	string Name = 1;
+	imported.Type Type = 2;
+	message Nested {
+		string value = 1;
+	}
+	Nested nested = 3;
+}
+-- util.gunk.golden --
+package util
+
+import (
+	imported "github.com/gunk/gunk/imported"
+)
+
+type EventRequest_Nested struct {
+	Value string `pb:"1" json:"value"`
+}
+
+type EventRequest struct {
+	Name   string              `pb:"1" json:"name"`
+	Type   imported.Type       `pb:"2" json:"type"`
+	Nested EventRequest_Nested `pb:"3" json:"nested"`
+}
+-- imported/imported.proto --
+syntax = "proto3";
+
+package imported;
+
+option go_package= "github.com/gunk/gunk/imported";
+
+message Type {
+	string Name = 1;
+}

--- a/testdata/scripts/convert_relative_import.txt
+++ b/testdata/scripts/convert_relative_import.txt
@@ -1,0 +1,48 @@
+env HOME=$WORK/home
+
+gunk convert pb/util.proto
+cmp pb/util.gunk util.gunk.golden
+
+-- .gunkconfig --
+import_path=pb
+-- pb/util.proto --
+syntax = "proto3";
+
+package util;
+
+import "imported/imported.proto";
+
+message EventRequest {
+	string Name = 1;
+	imported.Type Type = 2;
+	message Nested {
+		string value = 1;
+	}
+	Nested nested = 3;
+}
+-- util.gunk.golden --
+package util
+
+import (
+	imported "github.com/gunk/gunk/imported"
+)
+
+type EventRequest_Nested struct {
+	Value string `pb:"1" json:"value"`
+}
+
+type EventRequest struct {
+	Name   string              `pb:"1" json:"name"`
+	Type   imported.Type       `pb:"2" json:"type"`
+	Nested EventRequest_Nested `pb:"3" json:"nested"`
+}
+-- pb/imported/imported.proto --
+syntax = "proto3";
+
+package imported;
+
+option go_package= "github.com/gunk/gunk/imported";
+
+message Type {
+	string Name = 1;
+}


### PR DESCRIPTION
Add `[convert]` section to handle import when converting `.proto` to `.gunk`:
If `import_path` is provided within that section, gunk will pass this path to protoc in `LoadProto` method.
proto files passed will be parsed to retrieve `go_package` option value and added as import in resulting gunk file

Fix #198 