### PR TITLE
all: various cleanups

### DIFF
--- a/convert/convert.go
+++ b/convert/convert.go
@@ -1,6 +1,7 @@
 package convert
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -31,7 +32,6 @@ func Run(paths []string, overwrite bool) error {
 }
 
 func run(path string, overwrite bool, protocPath string) error {
-
 	fi, err := os.Stat(path)
 	if err != nil {
 		return err
@@ -91,13 +91,12 @@ func convertFile(path string, overwrite bool, importPath string, protocPath stri
 		return fmt.Errorf("path already exists %q, use --overwrite", fullpath)
 	}
 
-	w := &strings.Builder{}
-	if err := loader.ConvertFromProto(w, file, filename, importPath, protocPath); err != nil {
+	var b bytes.Buffer
+	if err := loader.ConvertFromProto(&b, file, filename, importPath, protocPath); err != nil {
 		return err
 	}
 
-	result := []byte(w.String())
-	result, err = format.Source(result)
+	result, err := format.Source(b.Bytes())
 	if err != nil {
 		return err
 	}

--- a/generate/download.go
+++ b/generate/download.go
@@ -131,7 +131,6 @@ func downloadAndExtractProtoc(protocCachePath string) error {
 // 	- osx-x86_64
 // 	- win32
 func protocDownloadURL() (string, error) {
-
 	// Translate the arch to what the protoc download expects.
 	var arch string
 	switch a := runtime.GOARCH; a {

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -488,7 +488,7 @@ func (g *Generator) fileOptions(pkg *loader.GunkPackage) (*desc.FileOptions, err
 				fo.PhpClassPrefix = proto.String(constant.StringVal(tag.Value))
 			case "github.com/gunk/opt/file/php.MetadataNamespace":
 				// TODO: This isn't currently in protoc-gen-go decriptor.pb.go
-				//fo.PhpMetadataNamespace = proto.String(constant.StringVal(tag.Value))
+				// fo.PhpMetadataNamespace = proto.String(constant.StringVal(tag.Value))
 			case "github.com/gunk/opt/file/php.GenericServices":
 				fo.PhpGenericServices = proto.Bool(constant.BoolVal(tag.Value))
 			default:
@@ -1018,6 +1018,7 @@ func (g *Generator) convertEnum(tspec *ast.TypeSpec) (*desc.EnumDescriptorProto,
 			}
 			// To avoid duplicate prefix (protoc-gen-go),
 			// we remove the enum type name if present
+			// TODO: not covered by any test?
 			prefix := *enum.Name + "_"
 			if strings.Contains(name.Name, prefix) {
 				name.Name = strings.Replace(name.Name, prefix, "", 1)

--- a/go.mod
+++ b/go.mod
@@ -18,3 +18,5 @@ require (
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/yaml.v2 v2.2.2 // indirect
 )
+
+go 1.13

--- a/main_test.go
+++ b/main_test.go
@@ -18,7 +18,6 @@ import (
 var write = flag.Bool("w", false, "overwrite testdata output files")
 
 func TestMain(m *testing.M) {
-
 	if os.Getenv("TESTSCRIPT_COMMAND") == "" {
 		flag.Parse()
 		// Don't put the binaries in a temporary directory to delete, as that

--- a/testdata/generate/go.mod
+++ b/testdata/generate/go.mod
@@ -9,3 +9,5 @@ require (
 	google.golang.org/genproto v0.0.0-20190111180523-db91494dd46c
 	google.golang.org/grpc v1.18.0
 )
+
+go 1.13


### PR DESCRIPTION
Use bytes.Buffer when we need bytes.

Less string handling with types.

Finally, %s already calls the String method, so we can avoid the
repetition.