### PR TITLE
make printing of annotations deterministic

### DIFF
--- a/testdata/scripts/convert_complete_swagger.txt
+++ b/testdata/scripts/convert_complete_swagger.txt
@@ -1,18 +1,7 @@
 env HOME=$WORK/home
 
 gunk convert util.proto
-
-grep '\+gunk openapiv2.Swagger' util.gunk
-grep 'Swagger: "2.0"' util.gunk
-grep 'Info: openapiv2.Info' util.gunk
-grep 'Host' util.gunk
-grep 'BasePath' util.gunk
-grep 'Schemes: \[\]openapiv2.SwaggerScheme' util.gunk
-grep 'Consumes: \[\]string' util.gunk
-grep 'Produces: \[\]string' util.gunk
-grep 'Responses: map\[string\]openapiv2.Response' util.gunk
-grep 'SecurityDefinitions: openapiv2.SecurityDefinitions' util.gunk
-grep 'ExternalDocs: openapiv2.ExternalDocumentation' util.gunk
+cmp util.gunk util.gunk.golden
 
 -- util.proto --
 syntax = "proto3";
@@ -159,4 +148,146 @@ service Service {
       get : "/v1/message/{Name}"
     };
   }
+}
+-- util.gunk.golden --
+// +gunk openapiv2.Swagger{
+//         Swagger: "2.0",
+//         Info: openapiv2.Info{
+//                 Title:       "this is a title",
+//                 Description: "this is a description",
+//                 Contact: openapiv2.Contact{
+//                         Name:   "gunk",
+//                         URL:    "https://github.com/gunk/gunk",
+//                         Email:  "none@example.com",
+//                 },
+//                 License: openapiv2.License{
+//                         Name:   "MIT License",
+//                         URL:    "https://github.com/gunk/gunk/blob/master/LICENSE",
+//                 },
+//                 Version: "1.0",
+//         },
+//         Host:     "brank.as",
+//         BasePath: "/v1",
+//         Schemes: []openapiv2.SwaggerScheme{
+//                 openapiv2.HTTP,
+//                 openapiv2.HTTPS,
+//                 openapiv2.WSS,
+//         },
+//         Consumes: []string{
+//                 "application/json",
+//                 "application/x-foo-mime",
+//         },
+//         Produces: []string{
+//                 "application/json",
+//                 "application/x-foo-mime",
+//         },
+//         Responses: map[string]openapiv2.Response{
+//                 "403": openapiv2.Response{
+//                         Description: "Returned when the user does not have permission to access the resource.",
+//                 },
+//                 "404": openapiv2.Response{
+//                         Description: "Returned when the resource does not exist.",
+//                         Schema: openapiv2.Schema{
+//                                 JSONSchema: openapiv2.JSONSchema{
+//                                         Type: []openapiv2.JSONSchemaSimpleTypes{
+//                                                 openapiv2.STRING,
+//                                         },
+//                                 },
+//                         },
+//                 },
+//                 "418": openapiv2.Response{
+//                         Description: "I'm a teapot.",
+//                         Schema: openapiv2.Schema{
+//                                 JSONSchema: openapiv2.JSONSchema{
+//                                         Ref:              ".grpc.gateway.examples.examplepb.NumericEnum",
+//                                         Title:            "my title",
+//                                         MultipleOf:       2,
+//                                         Maximum:          10,
+//                                         ExclusiveMaximum: true,
+//                                         Minimum:          1,
+//                                         ExclusiveMinimum: true,
+//                                         MaxLength:        10,
+//                                         MinLength:        5,
+//                                         Pattern:          "test pattern",
+//                                         MaxItems:         10,
+//                                         MinItems:         2,
+//                                         UniqueItems:      true,
+//                                         MaxProperties:    100,
+//                                         MinProperties:    50,
+//                                         Required: []string{
+//                                                 "name",
+//                                                 "date",
+//                                         },
+//                                         Array: []string{
+//                                                 "arr1",
+//                                                 "arr2",
+//                                         },
+//                                         Type: []openapiv2.JSONSchemaSimpleTypes{
+//                                                 openapiv2.STRING,
+//                                         },
+//                                 },
+//                                 Discriminator: "it's a discriminator",
+//                                 ReadOnly:      true,
+//                                 ExternalDocs: openapiv2.ExternalDocumentation{
+//                                         Description: "More about gunk 418",
+//                                         URL:         "https://github.com/gunk/gunk",
+//                                 },
+//                         },
+//                 },
+//         },
+//         SecurityDefinitions: openapiv2.SecurityDefinitions{
+//                 Security: map[string]openapiv2.SecurityScheme{
+//                         "ApiKeyAuth": openapiv2.SecurityScheme{
+//                                 Type:   openapiv2.TYPE_API_KEY,
+//                                 Name:   "X-API-Key",
+//                                 In:     openapiv2.IN_HEADER,
+//                         },
+//                         "BasicAuth": openapiv2.SecurityScheme{
+//                                 Type: openapiv2.TYPE_BASIC,
+//                         },
+//                         "OAuth2": openapiv2.SecurityScheme{
+//                                 Type:             openapiv2.TYPE_OAUTH2,
+//                                 Description:      "this is a security scheme description",
+//                                 Flow:             openapiv2.FLOW_ACCESS_CODE,
+//                                 AuthorizationURL: "https://example.com/oauth/authorize",
+//                                 TokenURL:         "https://example.com/oauth/token",
+//                                 Scopes: openapiv2.Scopes{
+//                                         Scope: map[string]string{
+//                                                 "admin": "Grants read and write access to administrative information",
+//                                                 "read":  "Grants read access",
+//                                                 "write": "Grants write access",
+//                                         },
+//                                 },
+//                         },
+//                 },
+//         },
+//         ExternalDocs: openapiv2.ExternalDocumentation{
+//                 Description: "More about gunk",
+//                 URL:         "https://github.com/gunk/gunk",
+//         },
+// }
+package test
+
+import (
+	"github.com/gunk/opt/http"
+	"github.com/gunk/opt/openapiv2"
+	// "protoc-gen-swagger/options/annotations.proto"
+)
+
+// Message comment
+type Message struct {
+	Name string `pb:"1" json:"name"`
+}
+
+type Service interface {
+	// +gunk openapiv2.Operation{
+	//         Tags:        []string{"Message"},
+	//         Description: "Get message",
+	//         Summary:     "Retrieves message",
+	// }
+	// +gunk http.Match{
+	//         Method: "GET",
+	//         Path:   "/v1/message/{Name}",
+	// }
+	GetMessage(Message) Message
 }


### PR DESCRIPTION
We can't directly range over a map's keys, as their order is randomized.

This means we can make the swagger test much stronger and simpler.