### PR TITLE
testdata/mod: fix the module copies

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -136,6 +136,7 @@ func TestScripts(t *testing.T) {
 		Dir: filepath.Join("testdata", "scripts"),
 		Setup: func(e *testscript.Env) error {
 			e.Vars = append(e.Vars, "GOPROXY="+proxyURL)
+			e.Vars = append(e.Vars, "GONOSUMDB=*")
 			return nil
 		},
 	})

--- a/testdata/mod/github.com_golang_protobuf_v1.3.1.txt
+++ b/testdata/mod/github.com_golang_protobuf_v1.3.1.txt
@@ -1,0 +1,6 @@
+module github.com/golang/protobuf@v1.3.1
+
+-- .mod --
+module github.com/golang/protobuf
+-- .info --
+{"Version":"v1.3.1","Time":"2019-02-28T07:19:29-08:00"}

--- a/testdata/mod/github.com_gunk_opt_v0.0.0-20190514110406-385321f21939.txt
+++ b/testdata/mod/github.com_gunk_opt_v0.0.0-20190514110406-385321f21939.txt
@@ -1,9 +1,13 @@
-module github.com/gunk/opt@latest
+module github.com/gunk/opt@v0.0.0-20190514110406-385321f21939
 
 -- .mod --
 module github.com/gunk/opt
+
+go 1.12
+
+require github.com/golang/protobuf v1.3.1
 -- .info --
-{"Version":"v0.0.0-20190514110406-385321f21939","Time":"2019-05-14T11:04:06Z"}
+{"Version":"v0.0.0-20190514110406-385321f21939","Time":"2019-05-14T04:04:06-07:00"}
 -- LICENSE --
 The MIT License (MIT)
 


### PR DESCRIPTION
gunk/opt was invalid, as reported by sum.golang.org; go.mod had been
tampered somehow. Re-add it.

We also need to be able to resolve github.com/google/protobuf. The
module is massive, and txtar-addmod would add ~1.5MiB in a file.
Fortunately, we just need to resolve the module, and not build it.

So a stub txtar file is enough. Turn off sum.golang.org, as it
(correctly) reports that the source is different. We don't care.

With these changes, 'go test' passes on 'go version devel +d97bd5d07a
Sat May 25 22:38:01 2019 +0000 linux/amd64'.