### PR TITLE
all: handle the complete Operation definition from swagger

### DIFF
--- a/reflectutil/setter.go
+++ b/reflectutil/setter.go
@@ -26,7 +26,7 @@ func SetValue(structPtr interface{}, name, value string) {
 	}
 	var v interface{}
 	var err error
-	switch k := tmp.Type().Kind(); k {
+	switch k := tmp.Type(); k.Kind() {
 	case reflect.String:
 		v = value
 	case reflect.Float64:
@@ -35,6 +35,13 @@ func SetValue(structPtr interface{}, name, value string) {
 		v, err = strconv.ParseBool(value)
 	case reflect.Uint64:
 		v, err = strconv.ParseUint(value, 10, 64)
+	case reflect.Slice:
+		switch k.Elem().Kind() {
+		case reflect.String:
+			v = reflect.Append(tmp, reflect.ValueOf(value)).Interface()
+		default:
+			panic(fmt.Errorf("slice of %s not supported", k.Elem().String()))
+		}
 	default:
 		panic(fmt.Errorf("%s not supported", k.String()))
 	}

--- a/testdata/scripts/convert_complete_swagger.txt
+++ b/testdata/scripts/convert_complete_swagger.txt
@@ -131,6 +131,14 @@ option (grpc.gateway.protoc_gen_swagger.options.openapiv2_swagger) = {
 			}
 		}
 	}
+	security: {
+        security_requirement: {
+          key: "ApiKeyAuth";
+          value: {
+            scope:"update";
+          }
+        }
+      }
 };
 
 // Message comment
@@ -262,6 +270,17 @@ service Service {
 //                         },
 //                 },
 //         },
+//         Security: []openapiv2.SecurityRequirement{
+//                 {
+//                         SecurityRequirement: map[string]openapiv2.SecurityRequirement_SecurityRequirementValue{
+//                                 "ApiKeyAuth": openapiv2.SecurityRequirement_SecurityRequirementValue{
+//                                         Scope: []string{
+//                                                 "update",
+//                                         },
+//                                 },
+//                         },
+//                 },
+//         },
 //         ExternalDocs: openapiv2.ExternalDocumentation{
 //                 Description: "More about gunk",
 //                 URL:         "https://github.com/gunk/gunk",
@@ -283,9 +302,11 @@ type Message struct {
 
 type Service interface {
 	// +gunk openapiv2.Operation{
-	//         Tags:        []string{"Message"},
-	//         Description: "Get message",
+	//         Tags: []string{
+	//                 "Message",
+	//         },
 	//         Summary:     "Retrieves message",
+	//         Description: "Get message",
 	// }
 	// +gunk http.Match{
 	//         Method: "GET",

--- a/testdata/scripts/convert_options_openapiv2.txt
+++ b/testdata/scripts/convert_options_openapiv2.txt
@@ -8,33 +8,57 @@ syntax = "proto3";
 
 package util;
 
-message GetAccountRequest { string account_id = 1; }
-
-// Account contains information for a specific account.
-message Account {
-  option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
-    json_schema : {
-      title : "Account detail"
-      description : "Detail information of account"
-    }
-  };
-  option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
-	  example: { value: '{ "success": true, "error_code": "0", "error_message": "" }' }
-  };
-  string account_id = 1;
+// Message comment
+message Message {
+	string Name = 1;
 }
 
-// AccountService provides account management service endpoints.
-service AccountService {
-  // GetAccount retrieves account information.
-  rpc GetAccount(GetAccountRequest) returns (Account) {
+service Service {
+  rpc GetMessage(Message) returns (Message) {
     option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {
-      description : "Get account information"
-      summary : "Retrieves account information"
-      tags : "Account"
+      tags : "tag 1"
+      tags : "tag 2"
+      summary : "Retrieves message"
+      description : "Get message"
+      external_docs: {
+        url: "https://github.com/grpc-ecosystem/grpc-gateway";
+        description: "Find out more about GetQuery";
+      }
+      operation_id:"operation_id"
+      consumes: "application/json"
+      produces: "application/xml"
+      responses: {
+        key: "404";
+        value: {
+            description: "Returned when the resource does not exist.";
+        }
+      }
+      schemes: "scheme 1"
+      schemes: "scheme 2"
+      deprecated: true
+      security: {
+				security_requirement: {
+          key: "empty";
+          value: {
+					}
+        }
+        security_requirement: {
+          key: "ApiKeyAuth";
+          value: {
+						scope: "update";
+					}
+        }
+        security_requirement: {
+          key: "OAuth2";
+          value: {
+            scope: "read";
+            scope: "write";
+          }
+        }
+      }
     };
     option (google.api.http) = {
-      get : "/v1/account/{account_id}"
+      get : "/v1/message/{Name}"
     };
   }
 }
@@ -47,33 +71,61 @@ import (
 	"github.com/gunk/opt/openapiv2"
 )
 
-type GetAccountRequest struct {
-	AccountID string `pb:"1" json:"account_id"`
+// Message comment
+type Message struct {
+	Name string `pb:"1" json:"name"`
 }
 
-// Account contains information for a specific account.
-type Account struct {
-	// +gunk openapiv2.Schema{
-	//         JSONSchema: openapiv2.JSONSchema{Title: "Account detail", Description: "Detail information of account"},
-	// }
-	// +gunk openapiv2.Schema{
-	//         Example: openapiv2.Any{Value: []byte(`{"success":true,"error_code":"0","error_message":""}`)},
-	// }
-	AccountID string `pb:"1" json:"account_id"`
-}
-
-// AccountService provides account management service endpoints.
-type AccountService interface {
-	// GetAccount retrieves account information.
-	//
+type Service interface {
 	// +gunk openapiv2.Operation{
-	//         Tags:        []string{"Account"},
-	//         Description: "Get account information",
-	//         Summary:     "Retrieves account information",
+	//         Tags: []string{
+	//                 "tag 1",
+	//                 "tag 2",
+	//         },
+	//         Summary:     "Retrieves message",
+	//         Description: "Get message",
+	//         ExternalDocs: openapiv2.ExternalDocumentation{
+	//                 Description: "Find out more about GetQuery",
+	//                 URL:         "https://github.com/grpc-ecosystem/grpc-gateway",
+	//         },
+	//         OperationID: "operation_id",
+	//         Consumes: []string{
+	//                 "application/json",
+	//         },
+	//         Produces: []string{
+	//                 "application/xml",
+	//         },
+	//         Responses: map[string]openapiv2.Response{
+	//                 "404": openapiv2.Response{
+	//                         Description: "Returned when the resource does not exist.",
+	//                 },
+	//         },
+	//         Schemes: []string{
+	//                 "scheme 1",
+	//                 "scheme 2",
+	//         },
+	//         Deprecated: true,
+	//         Security: []openapiv2.SecurityRequirement{
+	//                 {
+	//                         SecurityRequirement: map[string]openapiv2.SecurityRequirement_SecurityRequirementValue{
+	//                                 "ApiKeyAuth": openapiv2.SecurityRequirement_SecurityRequirementValue{
+	//                                         Scope: []string{
+	//                                                 "update",
+	//                                         },
+	//                                 },
+	//                                 "OAuth2": openapiv2.SecurityRequirement_SecurityRequirementValue{
+	//                                         Scope: []string{
+	//                                                 "read",
+	//                                                 "write",
+	//                                         },
+	//                                 },
+	//                         },
+	//                 },
+	//         },
 	// }
 	// +gunk http.Match{
 	//         Method: "GET",
-	//         Path:   "/v1/account/{AccountID}",
+	//         Path:   "/v1/message/{Name}",
 	// }
-	GetAccount(GetAccountRequest) Account
+	GetMessage(Message) Message
 }

--- a/testdata/scripts/generate_complete_swagger.txt
+++ b/testdata/scripts/generate_complete_swagger.txt
@@ -143,6 +143,13 @@ require (
       }
     }
   },
+  "security": [
+    {
+      "ApiKeyAuth": [
+        "update"
+      ]
+    }
+  ],
   "externalDocs": {
     "description": "More about gunk",
     "url": "https://github.com/gunk/gunk"
@@ -255,6 +262,17 @@ require (
 //                                                 "admin": "Grants read and write access to administrative information",
 //                                                 "read":  "Grants read access",
 //                                                 "write": "Grants write access",
+//                                         },
+//                                 },
+//                         },
+//                 },
+//         },
+//         Security: []openapiv2.SecurityRequirement{
+//                 {
+//                         SecurityRequirement: map[string]openapiv2.SecurityRequirement_SecurityRequirementValue{
+//                                 "ApiKeyAuth": openapiv2.SecurityRequirement_SecurityRequirementValue{
+//                                         Scope: []string{
+//                                                 "update",
 //                                         },
 //                                 },
 //                         },

--- a/testdata/scripts/generate_options_openapiv2.txt
+++ b/testdata/scripts/generate_options_openapiv2.txt
@@ -2,12 +2,7 @@ env HOME=$WORK/home
 
 gunk generate echo.gunk
 
-exists all.swagger.json
-grep '"/v1/account/{AccountID}"' all.swagger.json
-grep '"summary": "Retrieves account information"' all.swagger.json
-grep '"description": "Get account information"' all.swagger.json
-grep 'Detail information of account' all.swagger.json
-grep 'Account detail' all.swagger.json
+cmp all.swagger.json all.swagger.json.golden
 
 -- go.mod --
 module testdata.tld/util
@@ -18,40 +13,152 @@ require (
 -- .gunkconfig --
 [generate swagger]
 -- echo.gunk --
-package util
+// +gunk openapiv2.Swagger{
+//         Swagger: "2.0",
+//         Info: openapiv2.Info{
+//                 Title: "this is a title",
+//         },
+// }
+package test
 
 import (
 	"github.com/gunk/opt/http"
 	"github.com/gunk/opt/openapiv2"
 )
 
-type GetAccountRequest struct {
-	AccountID string `pb:"1" json:"account_id"`
+// Message comment
+type Message struct {
+	Name string `pb:"1" json:"name"`
 }
 
-// Account contains information for a specific account.
-type Account struct {
-	// +gunk openapiv2.Schema{
-	//         JSONSchema: openapiv2.JSONSchema{Title: "Account detail", Description: "Detail information of account"},
-	// }
-	// +gunk openapiv2.Schema{
-	//         Example: openapiv2.Any{Value: []byte(`{"success":true,"error_code":"0","error_message":""}`)},
-	// }
-	AccountID string `pb:"1" json:"account_id"`
-}
-
-// AccountService provides account management service endpoints.
-type AccountService interface {
-	// GetAccount retrieves account information.
-	//
+type Service interface {
 	// +gunk openapiv2.Operation{
-	//         Tags:        []string{"Account"},
-	//         Description: "Get account information",
-	//         Summary:     "Retrieves account information",
+	//         Tags: []string{
+	//                 "tag 1",
+	//                 "tag 2",
+	//         },
+	//         Summary:     "Retrieves message",
+	//         Description: "Get message",
+	//         ExternalDocs: openapiv2.ExternalDocumentation{
+	//                 Description: "Find out more about GetQuery",
+	//                 URL:         "https://github.com/grpc-ecosystem/grpc-gateway",
+	//         },
+	//         OperationID: "operation_id",
+	//         Consumes: []string{
+	//                 "application/json",
+	//         },
+	//         Produces: []string{
+	//                 "application/xml",
+	//         },
+	//         Responses: map[string]openapiv2.Response{
+	//                 "404": openapiv2.Response{
+	//                         Description: "Returned when the resource does not exist.",
+	//                 },
+	//         },
+	//         Schemes: []string{
+	//                 "scheme 1",
+	//                 "scheme 2",
+	//         },
+	//         Deprecated: true,
+	//         Security: []openapiv2.SecurityRequirement{
+	//                 {
+	//                         SecurityRequirement: map[string]openapiv2.SecurityRequirement_SecurityRequirementValue{
+	//                                 "ApiKeyAuth": openapiv2.SecurityRequirement_SecurityRequirementValue{
+	//                                         Scope: []string{
+	//                                                 "update",
+	//                                         },
+	//                                 },
+	//                                 "OAuth2": openapiv2.SecurityRequirement_SecurityRequirementValue{
+	//                                         Scope: []string{
+	//                                                 "read",
+	//                                                 "write",
+	//                                         },
+	//                                 },
+	//                         },
+	//                 },
+	//         },
 	// }
 	// +gunk http.Match{
 	//         Method: "GET",
-	//         Path:   "/v1/account/{AccountID}",
+	//         Path:   "/v1/message/{Name}",
 	// }
-	GetAccount(GetAccountRequest) Account
+	GetMessage(Message) Message
+}
+-- all.swagger.json.golden --
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "this is a title",
+    "version": "version not set"
+  },
+  "schemes": [
+    "http",
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/v1/message/{Name}": {
+      "get": {
+        "summary": "Retrieves message",
+        "description": "Get message",
+        "operationId": "GetMessage",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/testMessage"
+            }
+          },
+          "404": {
+            "description": "Returned when the resource does not exist.",
+            "schema": {}
+          }
+        },
+        "parameters": [
+          {
+            "name": "Name",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "tag 1",
+          "tag 2"
+        ],
+        "deprecated": true,
+        "security": [
+          {
+            "ApiKeyAuth": [
+              "update"
+            ],
+            "OAuth2": [
+              "read",
+              "write"
+            ]
+          }
+        ],
+        "externalDocs": {
+          "description": "Find out more about GetQuery",
+          "url": "https://github.com/grpc-ecosystem/grpc-gateway"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "testMessage": {
+      "type": "object",
+      "properties": {
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "Message comment"
+    }
+  }
 }


### PR DESCRIPTION
Only tags, summary and description were handled from the operation model
This commit adds the remaining fields

- Add missing fields for Operation, convert and generate
- Add missing security field in Swagger, convert and generate (the security field is the same as in operation, so I took the opportunity to add it in swagger as well)