### PR TITLE
reflectutil: move more reflect magic here

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 language: go
 
 go:
-  - 1.11.x
   - 1.12.x
 
 env:

--- a/reflectutil/setter.go
+++ b/reflectutil/setter.go
@@ -2,39 +2,87 @@ package reflectutil
 
 import (
 	"fmt"
+	"go/ast"
 	"reflect"
 	"strconv"
 	"strings"
 )
 
-// SetValue assign value to the field
-// name of the struct structPtr.
+type protoLiteral interface {
+	SourceRepresentation() string
+}
+
+// SetValue assign value to the field name of the struct structPtr.
 // Returns an error if name is not found or structPtr cannot
 // be addressed.
-func SetValue(structPtr interface{}, name, value string) {
+func SetValue(structPtr interface{}, name, value interface{}) {
+	nameStr := ""
+	switch name := name.(type) {
+	case *ast.Ident:
+		nameStr = name.Name
+	case string:
+		nameStr = name
+	default:
+		panic(fmt.Errorf("invalid name type: %T", name))
+	}
+
 	// Performs a case insensitive search because generated structs by
 	// protoc don't follow the best practices from the go naming convention:
-	// initialisms should be all capitals
-	tmp := reflect.Indirect(reflect.ValueOf(structPtr)).FieldByNameFunc(func(s string) bool {
-		return strings.EqualFold(s, name)
+	// initialisms should be all capitals.
+	// Remove underscores too, so that foo_bar matches the field FooBar.
+	nameStr = strings.ReplaceAll(nameStr, "_", "")
+	tmp := reflect.ValueOf(structPtr).Elem().FieldByNameFunc(func(s string) bool {
+		return strings.EqualFold(s, nameStr)
 	})
 	if !tmp.IsValid() {
-		panic(fmt.Errorf("%s was not found in %T", name, structPtr))
+		panic(fmt.Errorf("%s was not found in %T", nameStr, structPtr))
 	}
-	if !tmp.CanAddr() {
-		panic(fmt.Errorf("%s from %T cannot be addressed", name, structPtr))
+
+	switch x := value.(type) {
+	case *ast.Ident:
+		value = x.Name
+	case *ast.BasicLit:
+		value = x.Value
+	case protoLiteral:
+		value = x.SourceRepresentation()
 	}
+
 	var v interface{}
 	var err error
 	switch k := tmp.Type(); k.Kind() {
 	case reflect.String:
-		v = value
+		switch value := value.(type) {
+		case string:
+			v, err = strconv.Unquote(value)
+		}
 	case reflect.Float64:
-		v, err = strconv.ParseFloat(value, 64)
+		switch value := value.(type) {
+		case float64:
+			v = value
+		case string:
+			v, err = strconv.ParseFloat(value, 64)
+		}
 	case reflect.Bool:
-		v, err = strconv.ParseBool(value)
+		switch value := value.(type) {
+		case bool:
+			v = value
+		case string:
+			v, err = strconv.ParseBool(value)
+		}
+	case reflect.Int32:
+		switch value := value.(type) {
+		case int32:
+			v = value
+		case string:
+			v, err = strconv.ParseInt(value, 10, 32)
+		}
 	case reflect.Uint64:
-		v, err = strconv.ParseUint(value, 10, 64)
+		switch value := value.(type) {
+		case uint64:
+			v = value
+		case string:
+			v, err = strconv.ParseUint(value, 10, 64)
+		}
 	case reflect.Slice:
 		switch k.Elem().Kind() {
 		case reflect.String:
@@ -42,11 +90,16 @@ func SetValue(structPtr interface{}, name, value string) {
 		default:
 			panic(fmt.Errorf("slice of %s not supported", k.Elem().String()))
 		}
-	default:
-		panic(fmt.Errorf("%s not supported", k.String()))
 	}
 	if err != nil {
 		panic(err)
 	}
-	tmp.Set(reflect.ValueOf(v))
+	if v == nil {
+		panic(fmt.Sprintf("%T is not a valid value for %s", value, tmp.Type()))
+	}
+	val := reflect.ValueOf(v)
+	if t := tmp.Type(); val.Type().ConvertibleTo(t) {
+		val = val.Convert(t)
+	}
+	tmp.Set(val)
 }


### PR DESCRIPTION
We can move a lot of work to this helper function. For example, grabbing
the name from an identifier key, the value from a literal, or unquoting
a value string.

Also make it support converting types, so we can assign an int32 value
to an enum field, since it has a named type.

We can also remove many uses of snaker; the field search was already
case-insensitive, so removing all underscores is all that we need to
make it work.

This means we can drastically simplify and unify many uses of SetValue,
making the meat of the code simpler and less verbose.