### PR TITLE
reflectutil: support all maps and enums

### DIFF
--- a/convert/convert.go
+++ b/convert/convert.go
@@ -98,6 +98,9 @@ func convertFile(path string, overwrite bool, importPath string, protocPath stri
 
 	result, err := format.Source(b.Bytes())
 	if err != nil {
+		// Also print the source being formatted, since the go/format
+		// error often points at a specific error in one of its lines.
+		fmt.Fprintln(os.Stderr, b.String())
 		return err
 	}
 

--- a/reflectutil/setter.go
+++ b/reflectutil/setter.go
@@ -7,12 +7,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/emicklei/proto"
+	protop "github.com/emicklei/proto"
+	"github.com/golang/protobuf/proto"
 )
-
-type protoLiteral interface {
-	SourceRepresentation() string
-}
 
 // SetValue assign value to the field name of the struct structPtr.
 // Returns an error if name is not found or structPtr cannot
@@ -33,24 +30,40 @@ func SetValue(structPtr interface{}, name, value interface{}) {
 	// initialisms should be all capitals.
 	// Remove underscores too, so that foo_bar matches the field FooBar.
 	nameStr = strings.ReplaceAll(nameStr, "_", "")
-	tmp := reflect.ValueOf(structPtr).Elem().FieldByNameFunc(func(s string) bool {
+	field, ok := reflect.TypeOf(structPtr).Elem().FieldByNameFunc(func(s string) bool {
 		return strings.EqualFold(s, nameStr)
 	})
-	if !tmp.IsValid() {
+	if !ok {
 		panic(fmt.Errorf("%s was not found in %T", nameStr, structPtr))
 	}
+	fval := reflect.ValueOf(structPtr).Elem().FieldByIndex(field.Index)
 
-	val := valueFor(tmp.Type(), value)
-	if tmp.Type().Kind() == reflect.Slice && val.Type().Kind() != reflect.Slice {
-		val = reflect.Append(tmp, val)
+	val := valueFor(field.Type, field.Tag, value)
+	switch field.Type.Kind() {
+	case reflect.Slice:
+		val = reflect.AppendSlice(fval, val)
+	case reflect.Map:
+		if fval.IsNil() {
+			fval.Set(reflect.MakeMap(field.Type))
+		}
+		iter := val.MapRange()
+		for iter.Next() {
+			fval.SetMapIndex(iter.Key(), iter.Value())
+		}
+		return
 	}
-	tmp.Set(val)
+	fval.Set(val)
 }
 
-func valueFor(typ reflect.Type, value interface{}) reflect.Value {
+func valueFor(typ reflect.Type, tag reflect.StructTag, value interface{}) reflect.Value {
+	if named, ok := value.(*protop.NamedLiteral); ok {
+		// We don't care about the name here.
+		value = named.Literal
+	}
+
 	switch typ.Kind() {
 	case reflect.Ptr:
-		return valueFor(typ.Elem(), value).Addr()
+		return valueFor(typ.Elem(), tag, value).Addr()
 	case reflect.Struct:
 		strc := reflect.New(typ)
 		switch value := value.(type) {
@@ -59,7 +72,7 @@ func valueFor(typ reflect.Type, value interface{}) reflect.Value {
 				kv := elt.(*ast.KeyValueExpr)
 				SetValue(strc.Interface(), kv.Key, kv.Value)
 			}
-		case *proto.NamedLiteral:
+		case *protop.Literal:
 			for _, lit := range value.OrderedMap {
 				SetValue(strc.Interface(), lit.Name, lit)
 			}
@@ -67,80 +80,94 @@ func valueFor(typ reflect.Type, value interface{}) reflect.Value {
 			panic(fmt.Sprintf("%T is not a valid value for %s", value, typ))
 		}
 		return strc.Elem()
+	case reflect.Map:
+		mp := reflect.MakeMap(typ)
+		switch value := value.(type) {
+		case *ast.CompositeLit:
+			for _, elt := range value.Elts {
+				kv := elt.(*ast.KeyValueExpr)
+				key := valueFor(typ.Key(), "", kv.Key)
+				val := valueFor(typ.Elem(), "", kv.Value)
+				mp.SetMapIndex(key, val)
+			}
+		case *protop.Literal:
+			key := valueFor(typ.Key(), "", value.OrderedMap[0])
+			val := valueFor(typ.Elem(), "", value.OrderedMap[1])
+			if key.Interface() == "empty" {
+				// TODO(mvdan): figure out why this happens
+				break
+			}
+			mp.SetMapIndex(key, val)
+		default:
+			panic(fmt.Sprintf("%T is not a valid value for %s", value, typ))
+		}
+		return mp
 	case reflect.Slice:
 		list := reflect.MakeSlice(typ, 0, 0)
 		switch value := value.(type) {
 		case *ast.CompositeLit:
 			for _, elt := range value.Elts {
-				list = reflect.Append(list, valueFor(typ.Elem(), elt))
+				list = reflect.Append(list, valueFor(typ.Elem(), tag, elt))
 			}
-		case *proto.Literal:
+		case *protop.Literal:
+			if value.Array == nil {
+				list = reflect.Append(list, valueFor(typ.Elem(), tag, value))
+				break
+			}
 			for _, lit := range value.Array {
-				list = reflect.Append(list, valueFor(typ.Elem(), lit))
+				list = reflect.Append(list, valueFor(typ.Elem(), tag, lit))
 			}
 		default:
-			// try appending a single element
-			// TODO(mvdan): remove later
-			return valueFor(typ.Elem(), value)
+			panic(fmt.Sprintf("%T is not a valid value for %s", value, typ))
 		}
 		return list
 	}
 
+	valueStr := ""
 	switch x := value.(type) {
 	case *ast.Ident:
-		value = x.Name
+		valueStr = x.Name
 	case *ast.BasicLit:
-		value = x.Value
-	case protoLiteral:
-		value = x.SourceRepresentation()
+		valueStr = x.Value
+	case *ast.SelectorExpr:
+		valueStr = x.Sel.Name
+	case *protop.Literal:
+		valueStr = x.SourceRepresentation()
+	}
+	value = reflect.Value{} // ensure we just use valueStr from this point
+
+	// If the field is an enum, decode it, and store it via a conversion
+	// from int32 to the named enum type.
+	for _, kv := range strings.Split(tag.Get("protobuf"), ",") {
+		kv := strings.SplitN(kv, "=", 2)
+		if kv[0] != "enum" {
+			continue
+		}
+		enumMap := proto.EnumValueMap(kv[1])
+		val, ok := enumMap[valueStr]
+		if !ok {
+			panic(fmt.Errorf("%q is not a valid %s", valueStr, kv[1]))
+		}
+		return reflect.ValueOf(val).Convert(typ)
 	}
 
 	var v interface{}
 	var err error
 	switch typ.Kind() {
 	case reflect.String:
-		switch value := value.(type) {
-		case string:
-			v, err = strconv.Unquote(value)
-		}
+		v, err = strconv.Unquote(valueStr)
 	case reflect.Float64:
-		switch value := value.(type) {
-		case float64:
-			v = value
-		case string:
-			v, err = strconv.ParseFloat(value, 64)
-		}
+		v, err = strconv.ParseFloat(valueStr, 64)
 	case reflect.Bool:
-		switch value := value.(type) {
-		case bool:
-			v = value
-		case string:
-			v, err = strconv.ParseBool(value)
-		}
-	case reflect.Int32:
-		switch value := value.(type) {
-		case int32:
-			v = value
-		case string:
-			v, err = strconv.ParseInt(value, 10, 32)
-		}
+		v, err = strconv.ParseBool(valueStr)
 	case reflect.Uint64:
-		switch value := value.(type) {
-		case uint64:
-			v = value
-		case string:
-			v, err = strconv.ParseUint(value, 10, 64)
-		}
+		v, err = strconv.ParseUint(valueStr, 10, 64)
 	}
 	if err != nil {
 		panic(err)
 	}
 	if v == nil {
-		panic(fmt.Sprintf("%T is not a valid value for %s", value, typ))
+		panic(fmt.Sprintf("%T is not a valid value for %s", valueStr, typ))
 	}
-	val := reflect.ValueOf(v)
-	if val.Type().ConvertibleTo(typ) {
-		val = val.Convert(typ)
-	}
-	return val
+	return reflect.ValueOf(v)
 }


### PR DESCRIPTION
Gets rid of almost all the rest of the boilerplate code. The only pieces
left are because SetValue can only deal with struct fields.

While at it, unindent and simplify fromStructToAnnotation.

Finally, make the final section of valueFor parse strings alone,
handling the special enum case separately.