### PR TITLE
docgen: add append mode for messages.pot and all.md

### DIFF
--- a/docgen/generate/generate.go
+++ b/docgen/generate/generate.go
@@ -39,7 +39,7 @@ func Run(w io.Writer, f *google_protobuf.FileDescriptorProto, lang []string) (po
 		Funcs(template.FuncMap{
 			"GetText": func(txt string) string {
 				if txt != "" {
-					pb.AddTranslations([]string{txt})
+					pb.AddTranslation(txt)
 				}
 				return fmt.Sprintf("%s", txt)
 			},

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -269,7 +269,10 @@ func (g *Generator) generatePlugin(req plugin.CodeGeneratorRequest, gen config.G
 	// Due to problems with some generators (grpc-gateway),
 	// we need to ensure we either send a non-empty string or nil.
 	if ps := gen.ParamString(); ps != "" {
-		req.Parameter = proto.String(gen.ParamString())
+		if gen.Out != "" {
+			ps += fmt.Sprintf(",out=%s", gen.Out)
+		}
+		req.Parameter = proto.String(ps)
 	}
 	bs, err := proto.Marshal(&req)
 	if err != nil {

--- a/testdata/scripts/extract_append.txt
+++ b/testdata/scripts/extract_append.txt
@@ -1,0 +1,412 @@
+gunk generate accounts.gunk
+gunk generate types.gunk
+cmp messages.pot messages.pot.golden
+cmp all.md all.md.golden
+
+-- go.mod --
+module testdata.tld/util
+
+require (
+	github.com/gunk/opt v0.0.0-20190514110406-385321f21939
+)
+-- .gunkconfig --
+[generate]
+command=docgen
+mode=append
+-- accounts.gunk --
+// +gunk openapiv2.Swagger{
+//         Swagger: "2.0",
+//         Info: openapiv2.Info{
+//                 Title:       "Accounts API",
+//                 Description: "Provides CRUD operations on the accounts resource.",
+//                 Version:     "1.0.0",
+//         },
+//		   Host: "https://openbank.com",
+//         BasePath: "/v1",
+// }
+package accounts
+
+import (
+	"github.com/gunk/opt/http"
+	"github.com/gunk/opt/openapiv2"
+)
+
+// Account holds all details about a bank account.
+type Account struct {
+	// AccountID is the unique identifier of an account.
+	// Should not be returned as is.
+	AccountID string `pb:"1" json:"account_id"`
+	// TODO: add comment.
+	Branch string `pb:"2" json:"branch"`
+	// TODO: add comment.
+	BranchName string `pb:"3" json:"branch_name"`
+	// Status is the status of the account.
+	Status string `pb:"4" json:"status"`
+}
+
+// GetAccountRequest is the request envelope to get an account by its identifier.
+type GetAccountRequest struct {
+	AccountID string `pb:"1" json:"account_id"`
+}
+
+// EntityType describes the type of the entity.
+type EntityType int
+
+const (
+	_ EntityType = iota
+	// Pers is an individual customer.
+	Pers
+	// Org is an organisation customer.
+	Org
+)
+
+// TODO: add comment.
+type AccountRole struct {
+	// TODO: add comment.
+	EntityNumber string `pb:"1" json:"entity_number"`
+	// TODO: add comment.
+	EntityType EntityType `pb:"2" json:"entity_type"`
+	// TODO: add comment.
+	Role string `pb:"3" json:"role"`
+}
+
+// TODO: add comment.
+type DebitTransaction struct {
+	// TODO: add comment.
+	Amount string `pb:"1" json:"amount"`
+	// TODO: add comment.
+	DebitAccount string `pb:"2" json:"debit_account"`
+	// TODO: add comment.
+	ExchangeRate string `pb:"3" json:"exchange_rate"`
+	// TODO: add comment.
+	IsFx bool `pb:"4" json:"is_fx"`
+}
+
+// AccountService provides Account operations.
+type AccountService interface {
+	// GetAccount retrieves the detail of an account, selected by its id.
+	//
+	// +gunk http.Match{
+	//         Method: "GET",
+	//         Path:   "/v1/accounts/{AccountID}",
+	// }
+	// +gunk openapiv2.Operation{
+	//         Tags:        []string{"Account"},
+	//         Description: "Retrieves all data from an account, selected by the account_id you supplied.",
+	//         Summary:     "Retrieve an account",
+	//         Responses: map[string]openapiv2.Response{
+	//                 "200": openapiv2.Response{
+	//                         Description: "Request executed successfully.",
+	//                         Schema: openapiv2.Schema{
+	//                                 JSONSchema: openapiv2.JSONSchema{
+	//                                         Ref: "#/definitions/accountsAccount",
+	//                                 },
+	//                         },
+	//                 },
+	//                 "404": openapiv2.Response{
+	//                         Description: "Returned when the resource is not found.",
+	//                 },
+	//         },
+	//         Security: []openapiv2.SecurityRequirement{
+	//                 {
+	//                         SecurityRequirement: map[string]openapiv2.SecurityRequirement_SecurityRequirementValue{
+	//                                 "OAuth2": openapiv2.SecurityRequirement_SecurityRequirementValue{
+	//                                         Scope: []string{
+	//                                                 "read",
+	//                                         },
+	//                                 },
+	//                         },
+	//                 },
+	//         },
+	// }
+	GetAccount(GetAccountRequest) Account
+}
+
+-- types.gunk --
+package types
+
+// Amount defines a transaction amount.
+type Amount struct {
+	// Cur is the currency of the amount.
+	Cur string `pb:"1" json:"cur"`
+	// Num is the value of the amount.
+	Num string `pb:"2" json:"num"`
+}
+
+// MajorType describes the type of the account.
+type MajorType int
+
+const (
+	_ MajorType = iota
+	// Checking account.
+	Checking
+	// Saving account.
+	Saving
+	// TimeDeposit for a time deposit account.
+	TimeDeposit
+	// CommercialLoan for a business loan account.
+	CommercialLoan
+	// MortgageLoan for a home loan account.
+	MortgageLoan
+	// ConsumerLoan for a consumer loan account.
+	ConsumerLoan
+)
+
+// MajorCategory describes the category of the account.
+type MajorCategory int
+
+const (
+	_ MajorCategory = iota
+	// Dep for deposit category.
+	Dep
+	// Loan for loan category.
+	Loan
+)
+
+// BankCode indicates which bank to use; these should be a list of banks
+// that we are currently integrated with
+// This is the updated list of banks per January 2018
+type BankCode int
+
+const (
+	_ BankCode = iota
+	Mandiri
+	Bca
+	Bni
+	Bri
+	DummyBank
+	Bdo
+	//Bpi
+	Aceh
+)
+
+-- messages.pot.golden --
+# Messages.pot - Contains all msgid extracted from swagger definitions.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid   ""
+msgstr  "Project-Id-Version: %s\n"
+		"Report-Msgid-Bugs-To: %s\n"
+		"POT-Creation-Date: %s\n"
+		"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+		"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+		"Language-Team: LANGUAGE <LL@li.org>\n"
+		"Language: \n"
+		"MIME-Version: 1.0\n"
+		"Content-Type: text/plain; charset=CHARSET\n"
+		"Content-Transfer-Encoding: 8bit\n"
+
+msgid "AccountID is the unique identifier of an account.Should not be returned as is."
+msgstr ""
+
+msgid "Accounts API"
+msgstr ""
+
+msgid "Amount defines a transaction amount."
+msgstr ""
+
+msgid "Annex"
+msgstr ""
+
+msgid "BankCode indicates which bank to use; these should be a list of banksthat we are currently integrated withThis is the updated list of banks per January 2018"
+msgstr ""
+
+msgid "Base Path"
+msgstr ""
+
+msgid "Bpi"
+msgstr ""
+
+msgid "Cur is the currency of the amount."
+msgstr ""
+
+msgid "EntityType describes the type of the entity."
+msgstr ""
+
+msgid "EntityType_Org is an organisation customer."
+msgstr ""
+
+msgid "EntityType_Pers is an individual customer."
+msgstr ""
+
+msgid "HTTP Request"
+msgstr ""
+
+msgid "Host"
+msgstr ""
+
+msgid "MajorCategory describes the category of the account."
+msgstr ""
+
+msgid "MajorCategory_Dep for deposit category."
+msgstr ""
+
+msgid "MajorCategory_Loan for loan category."
+msgstr ""
+
+msgid "MajorType describes the type of the account."
+msgstr ""
+
+msgid "MajorType_Checking account."
+msgstr ""
+
+msgid "MajorType_CommercialLoan for a business loan account."
+msgstr ""
+
+msgid "MajorType_ConsumerLoan for a consumer loan account."
+msgstr ""
+
+msgid "MajorType_MortgageLoan for a home loan account."
+msgstr ""
+
+msgid "MajorType_Saving account."
+msgstr ""
+
+msgid "MajorType_TimeDeposit for a time deposit account."
+msgstr ""
+
+msgid "Num is the value of the amount."
+msgstr ""
+
+msgid "Provides CRUD operations on the accounts resource."
+msgstr ""
+
+msgid "Query Parameters"
+msgstr ""
+
+msgid "Request executed successfully."
+msgstr ""
+
+msgid "Response body"
+msgstr ""
+
+msgid "Response codes"
+msgstr ""
+
+msgid "Responses"
+msgstr ""
+
+msgid "Retrieve an account"
+msgstr ""
+
+msgid "Retrieves all data from an account, selected by the account_id you supplied."
+msgstr ""
+
+msgid "Returned when the resource is not found."
+msgstr ""
+
+msgid "Status is the status of the account."
+msgstr ""
+
+msgid "TODO: add comment."
+msgstr ""
+
+msgid "USE_YOUR_TOKEN"
+msgstr ""
+-- all.md.golden --
+
+# Accounts API v1.0.0
+
+Provides CRUD operations on the accounts resource.  
+* Host `https://openbank.com`  
+* Base Path `/v1`
+
+## Retrieve an account
+
+Retrieves all data from an account, selected by the account_id you supplied.
+
+```sh
+curl -X GET \
+	https://openbank.com/v1/accounts/{AccountID} \
+	-H 'Authorization: Bearer USE_YOUR_TOKEN'
+```
+### HTTP Request
+
+`GET https://openbank.com/v1/accounts/{AccountID}`
+
+### Query Parameters
+
+| Name      | Type   | Description |
+|-----------|--------|-------------|
+| AccountID | string |             |
+
+### Responses
+
+#### Response body
+
+| Name       | Type   | Description                                                                    |
+|------------|--------|--------------------------------------------------------------------------------|
+| AccountID  | string | AccountID is the unique identifier of an account.Should not be returned as is. |
+| Branch     | string | TODO: add comment.                                                             |
+| BranchName | string | TODO: add comment.                                                             |
+| Status     | string | Status is the status of the account.                                           |
+
+<!-- TODO: add example -->
+#### Response codes
+
+| Status | Description                              |
+|--------|------------------------------------------|
+| 200    | Request executed successfully.           |
+| 404    | Returned when the resource is not found. |
+
+## Annex
+
+####  EntityType
+
+EntityType describes the type of the entity.
+
+| Value | Description                                 |
+|-------|---------------------------------------------|
+| Pers  | EntityType_Pers is an individual customer.  |
+| Org   | EntityType_Org is an organisation customer. |
+
+# Annex
+
+##  Amount
+
+Amount defines a transaction amount.
+
+| Name | Type   | Description                        |
+|------|--------|------------------------------------|
+| Cur  | string | Cur is the currency of the amount. |
+| Num  | string | Num is the value of the amount.    |
+
+##  BankCode
+
+BankCode indicates which bank to use; these should be a list of banksthat we are currently integrated withThis is the updated list of banks per January 2018
+
+| Value     | Description |
+|-----------|-------------|
+| Mandiri   |             |
+| Bca       |             |
+| Bni       |             |
+| Bri       |             |
+| DummyBank |             |
+| Bdo       |             |
+| Aceh      | Bpi         |
+
+##  MajorCategory
+
+MajorCategory describes the category of the account.
+
+| Value | Description                             |
+|-------|-----------------------------------------|
+| Dep   | MajorCategory_Dep for deposit category. |
+| Loan  | MajorCategory_Loan for loan category.   |
+
+##  MajorType
+
+MajorType describes the type of the account.
+
+| Value          | Description                                           |
+|----------------|-------------------------------------------------------|
+| Checking       | MajorType_Checking account.                           |
+| Saving         | MajorType_Saving account.                             |
+| TimeDeposit    | MajorType_TimeDeposit for a time deposit account.     |
+| CommercialLoan | MajorType_CommercialLoan for a business loan account. |
+| MortgageLoan   | MajorType_MortgageLoan for a home loan account.       |
+| ConsumerLoan   | MajorType_ConsumerLoan for a consumer loan account.   |
+


### PR DESCRIPTION
Add append mode in gunkconfig to allow appending service/annexe
documentation into an existing all.md. The same for the translations
messages.pot file.

While at it, change AddTranslations to AddTranslation as it was
never used with an array of translations