### PR TITLE
make protoc version, path configurable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,5 @@ env:
 install: true
 
 script:
-  - go run main.go download
+  - go run main.go download all
   - go test -coverprofile=cover.out -v ./...

--- a/README.md
+++ b/README.md
@@ -146,13 +146,13 @@ $ go get -u github.com/gunk/gunk
 
 ## Protobuf Dependency and Caching
 
-The `gunk` command-line tool uses the `protoc` command-line tool. If `protoc`
-is not available on `$PATH` (Linux/macOS) / `%PATH%` (Windows), `gunk` will
+The `gunk` command-line tool uses the `protoc` command-line tool. `gunk` can be configured
+to use `protoc` at a specified path. If it isn't available, `gunk` will
 [download the latest protobuf release][protobuf-releases] to the user's cache,
-for use.
+for use. It's also possible to pin a specific version, see the section on [protoc configuration][].
 
-**Note:** future releases of Gunk may provide the ability to configure a
-specific version of the `protoc` binary.
+[protoc configuration]: #section-protoc
+
 
 ## Protocol Types and Messages
 
@@ -178,10 +178,10 @@ type Util interface {
 	// Echo echoes a message.
 	//
 	// +gunk http.Match{
-	//		Method:	"POST",
-	// 		Path:	"/v1/echo",
-	// 		Body:	"*",
-	//	}
+	// 	Method:	"POST",
+	// 	Path:	"/v1/echo",
+	// 	Body:	"*",
+	// }
 	Echo(Message) Message
 }
 ```
@@ -259,8 +259,8 @@ Gunk's Go-derived syntax uses Go `const`'s for declaring enums:
 type MyEnum int
 
 const (
-    MYENUM  MyEnum = iota
-    MYENUM2
+	MYENUM MyEnum = iota
+	MYENUM2
 )
 ```
 
@@ -273,11 +273,11 @@ Gunk's Go-derived syntax uses Go `map`'s for declaring `map` fields:
 
 ```go
 type Project struct {
-    ProjectID string `pb:"1" json:"project_id"`
+	ProjectID string `pb:"1" json:"project_id"`
 }
 
 type GetProjectResponse struct {
-    Projects map[string]Project `pb:"1"`
+	Projects map[string]Project `pb:"1"`
 }
 ```
 
@@ -288,7 +288,7 @@ repeated field:
 
 ```go
 type MyMessage struct {
-    FieldA []string `pb:"1"`
+	FieldA []string `pb:"1"`
 }
 ```
 
@@ -298,7 +298,7 @@ Gunk's Go-derived syntax uses Go `chan` syntax for declaring streams:
 
 ```go
 type MessageService interface {
-    List(chan Message) chan Message
+	List(chan Message) chan Message
 }
 ```
 
@@ -320,14 +320,14 @@ or service:
 ```go
 // MyOption is an option.
 type MyOption struct {
-    Name string `pb:"1"`
+	Name string `pb:"1"`
 }
 
 // +gunk MyOption {
-//   Name: "test",
+// 	Name: "test",
 // }
 type MyMessage struct {
-    /* ... */
+	/* ... */
 }
 ```
 
@@ -377,6 +377,22 @@ command=protoc-gen-go
 out=v1/js
 protoc=js
 ```
+
+### Section `[protoc]`
+
+The path where to check for (or where to download) the `protoc` binary can be configured.
+The version can also be pinned.
+
+#### Parameters
+
+* `version` - the version of protoc to use. If unspecified, defaults
+  to the latest release available. Otherwise, gunk will either download the specified
+  version, or check that the version of `protoc` at the specified path matches what was
+  configured.
+
+* `path` - the path to check for the `protoc` binary. If unspecified, defaults appropriate user 
+   cache directory for the user's OS. If no file exists at the path, `gunk` will attempt to download
+   protoc.
 
 ### Section `[generate[ <type>]]`
 
@@ -442,16 +458,16 @@ annotations, such as Google HTTP options, including all builtin/standard
 package message
 
 import (
-    "github.com/gunk/opt/http"
-    "github.com/gunk/opt/file/java"
+	"github.com/gunk/opt/http"
+	"github.com/gunk/opt/file/java"
 )
 
 type Util interface {
 	// +gunk http.Match{
-	//		Method:	"POST",
-	// 		Path:	"/v1/echo",
-	// 		Body:	"*",
-	//	}
+	// 	Method:	"POST",
+	// 	Path:	"/v1/echo",
+	// 	Body:	"*",
+	// }
 	Echo()
 }
 ```

--- a/convert/convert.go
+++ b/convert/convert.go
@@ -17,21 +17,15 @@ import (
 // Run converts proto files or folders to gunk files, saving the files in
 // the same folder as the proto file.
 func Run(paths []string, overwrite bool) error {
-	// Check that protoc exists, if not download it.
-	protocPath, err := generate.CheckOrDownloadProtoc()
-	if err != nil {
-		return err
-	}
-
 	for _, path := range paths {
-		if err := run(path, overwrite, protocPath); err != nil {
+		if err := run(path, overwrite); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func run(path string, overwrite bool, protocPath string) error {
+func run(path string, overwrite bool) error {
 	fi, err := os.Stat(path)
 	if err != nil {
 		return err
@@ -40,9 +34,16 @@ func run(path string, overwrite bool, protocPath string) error {
 	// Look for a .gunkconfig
 	absPath, _ := filepath.Abs(path)
 	cfg, err := config.Load(filepath.Dir(absPath))
-	var importPath string
+	var cfgProtocPath, cfgProtocVer, importPath string
 	if err == nil {
 		importPath = filepath.Join(cfg.Dir, cfg.ImportPath)
+		cfgProtocPath = cfg.ProtocPath
+		cfgProtocVer = cfg.ProtocVersion
+	}
+
+	protocPath, err := generate.CheckOrDownloadProtoc(cfgProtocPath, cfgProtocVer)
+	if err != nil {
+		return err
 	}
 
 	// Determine whether the path is a file or a directory.

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -42,11 +42,6 @@ func Run(dir string, args ...string) error {
 	}
 
 	// Check that protoc exists, if not download it.
-	protocPath, err := CheckOrDownloadProtoc()
-	if err != nil {
-		return err
-	}
-
 	pkgs, err := g.Load(args...)
 	if err != nil {
 		return err
@@ -84,6 +79,11 @@ func Run(dir string, args ...string) error {
 	// Finally, run the code generators.
 	for _, pkg := range pkgs {
 		cfg := pkgConfigs[pkg.Dir]
+		protocPath, err := CheckOrDownloadProtoc(cfg.ProtocPath, cfg.ProtocVersion)
+		if err != nil {
+			return err
+		}
+
 		if err := g.GeneratePkg(pkg.PkgPath, cfg.Generators, protocPath); err != nil {
 			return err
 		}

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,6 @@ require (
 	golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb // indirect
 	golang.org/x/text v0.3.2 // indirect
 	golang.org/x/tools v0.0.0-20190706070813-72ffa07ba3db
-	google.golang.org/appengine v1.4.0 // indirect
 	google.golang.org/genproto v0.0.0-20190620144150-6af8c5fc6601
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/yaml.v2 v2.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,5 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Kunde21/markdownfmt v0.1.1 h1:Cvg9lPNizwHn3szvJR28k9wMinIoykvFJDSeJumdndo=
 github.com/Kunde21/markdownfmt v0.1.1/go.mod h1:MrtYzsu7MaBigmZi+NqX9m5vRx7/I9J3W8L9dA0WkGc=
@@ -16,6 +17,7 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/emicklei/proto v1.6.13 h1:8iuAuKbFmFhkmstObb0EV/Hrn9W+x6EuV1y5Da8Ye9E=
 github.com/emicklei/proto v1.6.13/go.mod h1:rn1FgRS/FANiZdD2djyH7TMA9jdRDcYQ9IEN9yvjX0A=
+github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -32,6 +34,7 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.2 h1:S+ef0492XaIknb8LMjcwgW2i3cNTzDY
 github.com/grpc-ecosystem/grpc-gateway v1.9.2/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/gunk/opt v0.0.0-20190514110406-385321f21939 h1:6o8km4OArmTAyGJjWBCiNmd8ZqkgFLQjD0vGoSGSYsI=
 github.com/gunk/opt v0.0.0-20190514110406-385321f21939/go.mod h1:9wP1gVodayD0zF7ZzMEKJr9myJv+4DnfjEWOEOtmpBY=
+github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
@@ -46,15 +49,20 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/magiconair/properties v1.8.0 h1:LLgXmsheXeRoUOBOjtwPQCWIYqM/LU1ayDtDePerRcY=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mattn/go-runewidth v0.0.3 h1:a+kO+98RDGEfo6asOGMmpodZq4FNtnGP54yps8BzLR4=
 github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.4 h1:2BvfKmzob6Bmd4YsL0zygOqfdFnK7GR4QL06Do4/p7Y=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
+github.com/mitchellh/go-homedir v1.0.0 h1:vKb8ShqSby24Yrqr/yDYkuFz8d0WUjys40rvnGC8aR0=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.0.0/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
+github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
+github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
+github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -71,11 +79,16 @@ github.com/shurcooL/sanitized_anchor_name v0.0.0-20170918181015-86672fcb3f95 h1:
 github.com/shurcooL/sanitized_anchor_name v0.0.0-20170918181015-86672fcb3f95/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
+github.com/spf13/afero v1.1.2 h1:m8/z1t7/fwjysjQRYbP0RD+bUIF/8tJwPdEZsI83ACI=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
+github.com/spf13/cast v1.2.0 h1:HHl1DSRbEQN2i8tJmtS6ViPyHx35+p51amrdsiTCrkg=
 github.com/spf13/cast v1.2.0/go.mod h1:r2rcYCSwa1IExKTDiTfzaxqT2FNHs8hODu4LnUfgKEg=
+github.com/spf13/cobra v0.0.3 h1:ZlrZ4XsMRm04Fr5pSFxBgfND2EBVa1nLpiy1stUsX/8=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
+github.com/spf13/jwalterweatherman v1.0.0 h1:XHEdyB+EcvlqZamSM4ZOMGlc93t6AcsBEu9Gc1vn7yk=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
+github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/viper v1.2.1 h1:bIcUwXqLseLF3BDAZduuNfekWG87ibtFxi59Bq+oI9M=
 github.com/spf13/viper v1.2.1/go.mod h1:P4AexN0a+C9tGAnUFNwDMYYZv3pjFuvmeiMyKRaNVlI=
@@ -109,6 +122,7 @@ golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb h1:fgwFCsaw9buMuxNd6+DQfAuSF
 golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/testdata/generate/go.sum
+++ b/testdata/generate/go.sum
@@ -44,6 +44,7 @@ google.golang.org/genproto v0.0.0-20190111180523-db91494dd46c h1:LZllHYjdJnynBfm
 google.golang.org/genproto v0.0.0-20190111180523-db91494dd46c/go.mod h1:7Ep/1NZk928CDR8SjdVbjWNpdIf6nzjE3BTgJDr2Atg=
 google.golang.org/grpc v1.16.0 h1:dz5IJGuC2BB7qXR5AyHNwAUBhZscK2xVez7mznh72sY=
 google.golang.org/grpc v1.16.0/go.mod h1:0JHn/cJsOMiMfNA9+DeHDlAU7KAAB5GDlYFpa9MZMio=
+google.golang.org/grpc v1.19.0 h1:cfg4PD8YEdSFnm7qLV4++93WcmhH2nIUhMjhdCvl3j8=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=

--- a/testdata/scripts/config_protoc.txt
+++ b/testdata/scripts/config_protoc.txt
@@ -1,0 +1,83 @@
+# TODO: use [!net] once it does something useful.
+# See https://github.com/rogpeppe/go-internal/issues/75.
+[short] skip 'requires network access' 
+
+# Use a separate $HOME, to not reuse a cached protoc.
+env HOME=$WORK/protoc_home
+
+# Specify a valid protoc version.
+#
+# Note that the parent gunkconfig uses an invalid
+# version but since it's overriden by any existing child config
+# (i.e. here and in the succeeding tests) nothing blows up
+gunk generate ./version
+exists protoc_home/.cache/gunk/protoc-v3.8.0
+exists version/all.pb.go
+
+# Specify an invalid version
+! gunk generate ./badversion
+stderr 'error: downloading protoc: could not find platform linux-x86_64 release asset for "invalid"'
+! exists badversion/all.pb.go
+
+# Don't specify a path or version
+gunk generate ./noversion
+exists protoc_home/.cache/gunk/protoc-latest
+exists noversion/all.pb.go
+
+# Specify the path where the first test's binary was downloaded to,
+# but specify a different version
+! gunk generate ./pathversion
+stderr 'error: want protoc version "v3.7.0" got "3.8.0"'
+! exists pathversion/all.pb.go
+
+-- go.mod --
+module testdata.tld/util
+
+-- .gunkconfig --
+[generate]
+version=ignored
+command=protoc-gen-go
+plugins=grpc
+
+-- version/.gunkconfig --
+[protoc]
+version=v3.8.0
+
+-- badversion/.gunkconfig --
+[protoc]
+version=invalid
+
+-- noversion/.gunkconfig --
+
+-- pathversion/.gunkconfig --
+[protoc]
+path=protoc_home/.cache/gunk/protoc-v3.8.0
+version=v3.7.0
+
+-- version/version.gunk --
+package version
+
+type Message struct {
+	Msg string `pb:"1"`
+}
+
+-- badversion/badversion.gunk --
+package badversion
+
+type Message struct {
+	Msg string `pb:"1"`
+}
+
+-- noversion/noversion.gunk --
+package noversion
+
+type Message struct {
+	Msg string `pb:"1"`
+}
+
+-- pathversion/pathversion.gunk --
+package pathversion
+
+type Message struct {
+	Msg string `pb:"1"`
+}

--- a/testdata/scripts/download.txt
+++ b/testdata/scripts/download.txt
@@ -5,11 +5,11 @@
 env HOME=$WORK/home
 
 # Download protoc.
-gunk download -v
+gunk download protoc -v
 ! stdout .
 stderr 'downloaded protoc to'
 
 # This shouldn't download anything.
-gunk download -v
+gunk download protoc -v
 ! stdout .
 ! stderr .


### PR DESCRIPTION
Add a protoc config section to allow users to pin a specific protoc
version. Make the path configurable as well- gunk will attempt to
execute the binary at the path, or if none exists, gunk will download
the binary to this path.

Add a subcommand to the download command. The user now has to specify
that they want to download protoc. This makes the download command
more flexible, for when we want to use it to download other
protoc-related tools. Allow users to specify the path and version
with the download command as well.

Update the README to reflect the changes and fix miscellaneous
formatting problems while at it.

[OB-367] #done