### PR TITLE
fix test config_protoc failures on non Linux OSes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,8 +20,8 @@ require (
 	golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb // indirect
 	golang.org/x/text v0.3.2 // indirect
 	golang.org/x/tools v0.0.0-20190706070813-72ffa07ba3db
+	google.golang.org/appengine v1.4.0 // indirect
 	google.golang.org/genproto v0.0.0-20190620144150-6af8c5fc6601
-	google.golang.org/grpc v1.19.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/yaml.v2 v2.2.2 // indirect
 )

--- a/main_test.go
+++ b/main_test.go
@@ -8,11 +8,13 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"testing"
 
-	"github.com/gunk/gunk/generate"
 	"github.com/rogpeppe/go-internal/goproxytest"
 	"github.com/rogpeppe/go-internal/testscript"
+
+	"github.com/gunk/gunk/generate"
 )
 
 var write = flag.Bool("w", false, "overwrite testdata output files")
@@ -138,13 +140,33 @@ func TestScripts(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	cachePath, err := userCachePath()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	testscript.Run(t, testscript.Params{
 		Dir: filepath.Join("testdata", "scripts"),
 		Setup: func(e *testscript.Env) error {
 			e.Vars = append(e.Vars, "GOPROXY="+proxyURL)
 			e.Vars = append(e.Vars, "GONOSUMDB=*")
 			e.Vars = append(e.Vars, "HOME="+home)
+			e.Vars = append(e.Vars, "CACHEPATH="+cachePath)
 			return nil
 		},
 	})
+}
+
+// userCacheDir returns relative path of user cached data directory from home directory.
+func userCachePath() (string, error) {
+	realUserCacheDir, err := os.UserCacheDir()
+	if err != nil {
+		return "", err
+	}
+	realHomeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimPrefix(realUserCacheDir, realHomeDir), nil
 }

--- a/testdata/scripts/config_protoc.txt
+++ b/testdata/scripts/config_protoc.txt
@@ -4,6 +4,7 @@
 
 # Use a separate $HOME, to not reuse a cached protoc.
 env HOME=$WORK/protoc_home
+env CACHEDIR=$HOME/$CACHEPATH
 
 # Specify a valid protoc version.
 #
@@ -11,21 +12,24 @@ env HOME=$WORK/protoc_home
 # version but since it's overriden by any existing child config
 # (i.e. here and in the succeeding tests) nothing blows up
 gunk generate ./version
-exists protoc_home/.cache/gunk/protoc-v3.8.0
+exists $CACHEDIR/gunk/protoc-v3.8.0
 exists version/all.pb.go
 
 # Specify an invalid version
 ! gunk generate ./badversion
-stderr 'error: downloading protoc: could not find platform linux-x86_64 release asset for "invalid"'
+stderr 'error: downloading protoc: could not find platform .* release asset for "invalid"'
 ! exists badversion/all.pb.go
 
 # Don't specify a path or version
 gunk generate ./noversion
-exists protoc_home/.cache/gunk/protoc-latest
+exists $CACHEDIR/gunk/protoc-latest
 exists noversion/all.pb.go
 
 # Specify the path where the first test's binary was downloaded to,
 # but specify a different version
+# copy the downloaded protoc-v3.8.0 to current directory to make
+# pathversion/.gunkconfig work correctly across OSes
+cp $CACHEDIR/gunk/protoc-v3.8.0 protoc-v3.8.0
 ! gunk generate ./pathversion
 stderr 'error: want protoc version "v3.7.0" got "3.8.0"'
 ! exists pathversion/all.pb.go
@@ -51,7 +55,7 @@ version=invalid
 
 -- pathversion/.gunkconfig --
 [protoc]
-path=protoc_home/.cache/gunk/protoc-v3.8.0
+path=./protoc-v3.8.0
 version=v3.7.0
 
 -- version/version.gunk --


### PR DESCRIPTION
- passing user cache dir variable to testscript
- changes pathversion test to work correctly across OSes