### PR TITLE
generate: give a better error if download hits a 403

### DIFF
--- a/generate/download.go
+++ b/generate/download.go
@@ -175,6 +175,12 @@ func githubAssets(repo, version string) (string, []githubAsset, error) {
 	}
 	defer res.Body.Close()
 
+	if res.StatusCode >= 400 {
+		// This can easily happen if we make tons of requests to GitHub
+		// from one machine, as the IP hits their default rate limit.
+		return "", nil, fmt.Errorf("GET %s: %s", urlstr, http.StatusText(res.StatusCode))
+	}
+
 	var release struct {
 		Name   string        `json:"name"`
 		Assets []githubAsset `json:"assets"`

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb // indirect
 	golang.org/x/text v0.3.2 // indirect
 	golang.org/x/tools v0.0.0-20190706070813-72ffa07ba3db
-	google.golang.org/appengine v1.4.0 // indirect
 	google.golang.org/genproto v0.0.0-20190620144150-6af8c5fc6601
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/yaml.v2 v2.2.2 // indirect


### PR DESCRIPTION
Status codes in the 4xx range don't give an error, so we have to check
for them ourselves. Do that.

For #248.