### PR TITLE
docgen: remove support for downloading latest version of protoc

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb // indirect
 	golang.org/x/text v0.3.2 // indirect
 	golang.org/x/tools v0.0.0-20190706070813-72ffa07ba3db
+	google.golang.org/appengine v1.4.0 // indirect
 	google.golang.org/genproto v0.0.0-20190620144150-6af8c5fc6601
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/yaml.v2 v2.2.2 // indirect

--- a/testdata/scripts/config_protoc.txt
+++ b/testdata/scripts/config_protoc.txt
@@ -17,12 +17,12 @@ exists version/all.pb.go
 
 # Specify an invalid version
 ! gunk generate ./badversion
-stderr 'error: downloading protoc: could not find platform .* release asset for "invalid"'
+stderr 'error: downloading protoc: invalid version: invalid'
 ! exists badversion/all.pb.go
 
 # Don't specify a path or version
 gunk generate ./noversion
-exists $CACHEDIR/gunk/protoc-latest
+exists $CACHEDIR/gunk/protoc-v3.9.1 # default version
 exists noversion/all.pb.go
 
 # Specify the path where the first test's binary was downloaded to,


### PR DESCRIPTION
to avoid hitting Github API rate limit

Fix #248 