### PR TITLE
fix infinite loop when generate unresolvable import

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -349,6 +349,11 @@ func (l *Loader) parseGunkPackage(pkg *GunkPackage) {
 		pkg.ProtoName = pkg.Name
 	}
 
+	// the reported error will be handle at generate.Run function.
+	if len(pkg.Errors) > 0 {
+		return
+	}
+
 	if !l.Types {
 		return
 	}

--- a/testdata/scripts/generate_nonexistent_import.txt
+++ b/testdata/scripts/generate_nonexistent_import.txt
@@ -1,0 +1,14 @@
+# make sure go modules is turned off, and GOPATH is set to a nonexistent directory
+env GO111MODULE=off GOPATH=/this-directory-does-not-exist
+! gunk generate echo.gunk -v
+stderr '.*could not import github.com/gunk/opt/http.*'
+
+-- .gunkconfig --
+[generate]
+command=protoc-gen-go
+-- echo.gunk --
+package util
+
+import (
+	"github.com/gunk/opt/http"
+)

--- a/testdata/scripts/loader_files.txt
+++ b/testdata/scripts/loader_files.txt
@@ -13,7 +13,7 @@ cmp p2/p2.gunk p2/p2.gunk.golden
 
 # loading files from different packages with types should error
 ! gunk generate p1/p1.gunk p2/p2.gunk
-stderr 'package p2; expected p1'
+stderr '-: gunk package name mismatch: "p1" "p2"'
 
 -- go.mod --
 module testdata.tld/util


### PR DESCRIPTION
when executing "generate" if an import package is unresolvable, gunk
creates infinite number of gunpkg-*.go files until terminated.
This happens because a recursive calls in Loader.Loop method that
occurs when check.Files returns an error.

Solution: terminate loader.Load if an error is reported.