### PR TITLE
scopegen: remove commas when generating Go const fields

### DIFF
--- a/scopegen/generate/go.go
+++ b/scopegen/generate/go.go
@@ -15,7 +15,7 @@ type AuthScope string
 {{ if .Scopes -}}
 const (
 {{- range $scope := .Scopes }}
-	Scope_{{ $scope.Name }} AuthScope = "{{ $scope.Value }}",
+	Scope_{{ $scope.Name }} AuthScope = "{{ $scope.Value }}"
 {{- end }}
 )
 

--- a/testdata/scripts/scopegen.txt
+++ b/testdata/scripts/scopegen.txt
@@ -1,4 +1,5 @@
 gunk generate -v echo.gunk
+exec go build all.scopes.go
 cmp all.scopes.json all.scopes.json.golden
 cmp all.scopes.go all.scopes.go.golden
 -- go.mod --
@@ -88,9 +89,9 @@ package test
 type AuthScope string
 
 const (
-	Scope_admin AuthScope = "Grants read and write access to administrative information",
-	Scope_read AuthScope = "Grants read access",
-	Scope_write AuthScope = "Grants write access",
+	Scope_admin AuthScope = "Grants read and write access to administrative information"
+	Scope_read AuthScope = "Grants read access"
+	Scope_write AuthScope = "Grants write access"
 )
 
 var AuthScopes = map[string][]AuthScope{

--- a/testdata/scripts/scopegen_no_swagger.txt
+++ b/testdata/scripts/scopegen_no_swagger.txt
@@ -1,4 +1,5 @@
 gunk generate -v echo.gunk
+exec go build all.scopes.go
 cmp all.scopes.json all.scopes.json.golden
 cmp all.scopes.go all.scopes.go.golden
 -- go.mod --


### PR DESCRIPTION
When generated, current Go const values are separated by commas.
This causes the generated all.scopes.go file to not work properly due to syntax error.
This was easily fixed by removing the comma in the generate file.