### PR TITLE
testdata/scripts: accounts for XDG_CACHE_HOME

### DIFF
--- a/testdata/scripts/config_protoc.txt
+++ b/testdata/scripts/config_protoc.txt
@@ -3,8 +3,12 @@
 [short] skip 'requires network access' 
 
 # Use a separate $HOME, to not reuse a cached protoc.
-env HOME=$WORK/protoc_home
-env CACHEDIR=$HOME/$CACHEPATH
+env VHOME=$WORK/protoc_home
+env HOME=$VHOME
+env LocalAppData=$VHOME
+env home=$VHOME
+env CACHEDIR=$VHOME$CACHEPATH
+env XDG_CACHE_HOME=$CACHEDIR
 
 # Specify a valid protoc version.
 #


### PR DESCRIPTION
test was failing due to having `XDG_CACHE_HOME` set locally, but not in
the test case, resulting in a discrepancy

sets the env var on the test, and while at it, also includes
`LocalAppData` for windows and `home` for plan9

ref: https://github.com/golang/go/blob/902d5aa84f8340752c20b93bfd450a6cefcf3952/src/os/file.go#L371

fixes #270