### PR TITLE
protoc-gen-go: add json_tag_postproc option

### DIFF
--- a/generate/generate.go
+++ b/generate/generate.go
@@ -298,6 +298,9 @@ func (g *Generator) generatePlugin(req plugin.CodeGeneratorRequest, gen config.G
 		pkgPath = filepath.Clean(pkgPath) // to remove trailing slashes
 		gpkg := g.gunkPkgs[pkgPath]
 		data := []byte(*rf.Content)
+		if data, err = postProcess(data, gen); err != nil {
+			return fmt.Errorf("failed to execute post processing: %s", err.Error())
+		}
 		dir := gen.OutPath(gpkg.Dir)
 		outPath := filepath.Join(dir, basename)
 		if err := ioutil.WriteFile(outPath, data, 0644); err != nil {

--- a/generate/post_process.go
+++ b/generate/post_process.go
@@ -1,0 +1,42 @@
+package generate
+
+import (
+	"strconv"
+
+	"github.com/gunk/gunk/config"
+)
+
+// parseBoolParam returns true if the given parameter name exists and is a truthful value.
+func parseBoolParam(paramName string, gen config.Generator) (bool, error) {
+	for _, param := range gen.Params {
+		if param.Key == paramName {
+			result, err := strconv.ParseBool(param.Value)
+			if err != nil {
+				return false, err
+			}
+			return result, nil
+		}
+	}
+	return false, nil
+}
+
+// postProcess processes the input file before writing to output file.
+func postProcess(input []byte, gen config.Generator) ([]byte, error) {
+	const (
+		protocGenGoCmd           = "protoc-gen-go"
+		jsonTagPostprocParamName = "json_tag_postproc"
+	)
+
+	switch gen.Command {
+	case protocGenGoCmd:
+		jsonTagPostprocEnabled, err := parseBoolParam(jsonTagPostprocParamName, gen)
+		if err != nil {
+			return nil, err
+		}
+		if jsonTagPostprocEnabled {
+			return jsonTagPostProcessor(input)
+		}
+	}
+
+	return input, nil
+}

--- a/generate/post_process_json.go
+++ b/generate/post_process_json.go
@@ -1,0 +1,88 @@
+package generate
+
+import (
+	"bytes"
+	"go/ast"
+	"go/format"
+	"go/parser"
+	"go/token"
+	"reflect"
+	"strings"
+)
+
+// jsonNameFromProtobufTag parse json name from protobuf tag, returns empty string if no json name is defined.
+// example: protobuf:"bytes,1,opt,name=FirstName,json=first_name,proto3"
+// result: first_name
+func jsonNameFromProtobufTag(tag string) string {
+	const jsonPartName = "json="
+
+	if len(tag) == 0 {
+		return ""
+	}
+
+	parts := strings.Split(tag, ",")
+	for _, part := range parts {
+		if strings.HasPrefix(part, jsonPartName) {
+			return strings.TrimPrefix(part, jsonPartName)
+		}
+	}
+	return ""
+}
+
+// jsonNameFromJSONTag returns the json name from json tag, returns empty string if not defined.
+func jsonNameFromJSONTag(tag string) string {
+	if len(tag) == 0 {
+		return ""
+	}
+
+	parts := strings.Split(tag, ",")
+	if len(parts) == 0 {
+		return ""
+	}
+	return parts[0]
+}
+
+func jsonTagPostProcessor(input []byte) ([]byte, error) {
+	const (
+		jsonTagName     = "json"
+		protobufTagName = "protobuf"
+	)
+
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "", input, parser.ParseComments)
+	if err != nil {
+		return nil, err
+	}
+
+	ast.Inspect(f, func(node ast.Node) bool {
+		structDecl, ok := node.(*ast.StructType)
+		if !ok {
+			return true
+		}
+
+		for i, field := range structDecl.Fields.List {
+			tagValue := field.Tag.Value
+			tagValue = strings.Trim(tagValue, "`")
+			tag := reflect.StructTag(tagValue)
+
+			jsonName := jsonNameFromJSONTag(tag.Get(jsonTagName))
+			protobufJSONName := jsonNameFromProtobufTag(tag.Get(protobufTagName))
+
+			if jsonName != "" && protobufJSONName != "" && jsonName != protobufJSONName {
+				text := strings.Replace(field.Tag.Value, `json:"`+jsonName, `json:"`+protobufJSONName, 1)
+				structDecl.Fields.List[i].Tag = &ast.BasicLit{
+					ValuePos: field.Tag.Pos(),
+					Kind:     field.Tag.Kind,
+					Value:    text,
+				}
+			}
+		}
+		return true
+	})
+
+	var output bytes.Buffer
+	if err = format.Node(&output, fset, f); err != nil {
+		return nil, err
+	}
+	return output.Bytes(), nil
+}

--- a/generate/post_process_json_test.go
+++ b/generate/post_process_json_test.go
@@ -1,0 +1,65 @@
+package generate
+
+import (
+	"testing"
+)
+
+func TestJSONTagPostProcessor(t *testing.T) {
+	tests := []struct {
+		input  string
+		output string
+	}{
+		{
+			input: `package test
+
+// Person represents a homo sapien instance.
+type Person struct {
+	FirstName            string   ` + "`" + `protobuf:"bytes,1,opt,name=FirstName,json=first_name,proto3" json:"FirstName,omitempty"` + "`" + `
+	LastName             string   ` + "`" + `protobuf:"bytes,2,opt,name=LastName,json=last_name,proto3" json:"LastName,omitempty"` + "`" + `
+	XXX_NoUnkeyedLiteral struct{} ` + "`" + `json:"-"` + "`" + `
+	XXX_unrecognized     []byte   ` + "`" + `json:"-"` + "`" + `
+	XXX_sizecache        int32    ` + "`" + `json:"-"` + "`" + `
+}
+`,
+			output: `package test
+
+// Person represents a homo sapien instance.
+type Person struct {
+	FirstName            string   ` + "`" + `protobuf:"bytes,1,opt,name=FirstName,json=first_name,proto3" json:"first_name,omitempty"` + "`" + `
+	LastName             string   ` + "`" + `protobuf:"bytes,2,opt,name=LastName,json=last_name,proto3" json:"last_name,omitempty"` + "`" + `
+	XXX_NoUnkeyedLiteral struct{} ` + "`" + `json:"-"` + "`" + `
+	XXX_unrecognized     []byte   ` + "`" + `json:"-"` + "`" + `
+	XXX_sizecache        int32    ` + "`" + `json:"-"` + "`" + `
+}
+`,
+		},
+		{
+			input: `// This file intentionally has many json strings to confuse the post processor
+package test
+
+type ABCJSONTest struct {
+	// JSONField is a json field
+	JSONField string ` + "`" + `json2:"abc"` + "`" + `
+}
+`,
+			output: `// This file intentionally has many json strings to confuse the post processor
+package test
+
+type ABCJSONTest struct {
+	// JSONField is a json field
+	JSONField string ` + "`" + `json2:"abc"` + "`" + `
+}
+`,
+		},
+	}
+
+	for _, tc := range tests {
+		output, err := jsonTagPostProcessor([]byte(tc.input))
+		if err != nil {
+			t.Fatalf("failed to postproc json struct tag: err=%s", err.Error())
+		}
+		if string(output) != tc.output {
+			t.Errorf("wrong JSON tag post process result: expected=%q actual=%q", tc.output, string(output))
+		}
+	}
+}

--- a/testdata/scripts/generate_go_json_tag_postproc.txt
+++ b/testdata/scripts/generate_go_json_tag_postproc.txt
@@ -1,0 +1,31 @@
+gunk generate -v ./...
+grep 'json:"first_name' enabled/all.pb.go
+grep 'json:"FirstName' disabled/all.pb.go
+
+-- go.mod --
+module testdata.tld/util
+
+-- enabled/.gunkconfig --
+[generate go]
+json_tag_postproc=true
+
+-- disabled/.gunkconfig --
+[generate go]
+
+-- enabled/echo.gunk --
+package test
+
+// Person represents a homo sapien instance.
+type Person struct {
+	FirstName string `pb:"1" json:"first_name"`
+	LastName string `pb:"2" json:"last_name"`
+}
+
+-- disabled/echo.gunk --
+package test
+
+// Person represents a homo sapien instance.
+type Person struct {
+	FirstName string `pb:"1" json:"first_name"`
+	LastName string `pb:"2" json:"last_name"`
+}


### PR DESCRIPTION
Given following gunk code snippet

    // Person represents a homo sapien instance.
    type Person struct {
    	FirstName string `pb:"1" json:"first_name"`
    	LastName string `pb:"2" json:"last_name"`
    }

Without `json_tag_postproc` enabled, the output is:

    	FirstName            string   `protobuf:"bytes,1,opt,name=FirstName,json=first_name,proto3" json:"FirstName,omitempty"`
    	LastName             string   `protobuf:"bytes,2,opt,name=LastName,json=last_name,proto3" json:"LastName,omitempty"`

With `json_tag_postproc` enabled, the JSON struct tag is fixed to has same value as the the one defined in protobuf tag

    	FirstName            string   `protobuf:"bytes,1,opt,name=FirstName,json=first_name,proto3" json:"first_name,omitempty"`
    	LastName             string   `protobuf:"bytes,2,opt,name=LastName,json=last_name,proto3" json:"last_name,omitempty"`

This option is disabled by default.

--

Context: the json tag inconsistency is caused by protoc-gen-go:

* the json struct tag is always the field name: https://github.com/golang/protobuf/blob/d23c5127dc24889085f8ccea5c9d560a57a879d8/protoc-gen-go/generator/generator.go#L2242
* the json attribute inside protobuf struct tag is set to JSOName field and fall back to field name if not defined: https://github.com/golang/protobuf/blob/d23c5127dc24889085f8ccea5c9d560a57a879d8/protoc-gen-go/generator/generator.go#L1555

The post processor fix the inconsistency, the same approach will be used for docgen and swaggergen to fix the wrong json key value in generated examples.

To be discussed:

* this PR added a `json_tag_postproc`  parameter, but it could be a annotation inside gunk file itself.
* the post processor is done by dumb regex search and replace. It could be done with AST parser, but I'm not sure if it is necessary.