### PR TITLE
generate_complete_swagger: wrong expected value for base path

### DIFF
--- a/testdata/scripts/generate_complete_swagger.txt
+++ b/testdata/scripts/generate_complete_swagger.txt
@@ -189,7 +189,7 @@ json_names_for_fields=true
     }
   },
   "host": "brank.as",
-  "basePath": "/v1",
+  "basePath": "/path",
   "schemes": [
     "http",
     "https",


### PR DESCRIPTION
This failure happens because @karel-3d PR https://github.com/gunk/gunk/pull/283 got merged before https://github.com/gunk/gunk/pull/287. Both PRs CI passed, but master is failing.