### PR TITLE
json_tag_postproc: fix panic with gRPC plugin enabled

### DIFF
--- a/generate/post_process_json.go
+++ b/generate/post_process_json.go
@@ -61,6 +61,9 @@ func jsonTagPostProcessor(input []byte) ([]byte, error) {
 		}
 
 		for i, field := range structDecl.Fields.List {
+			if field.Tag == nil {
+				continue
+			}
 			tagValue := field.Tag.Value
 			tagValue = strings.Trim(tagValue, "`")
 			tag := reflect.StructTag(tagValue)

--- a/testdata/scripts/generate_go_json_tag_postproc.txt
+++ b/testdata/scripts/generate_go_json_tag_postproc.txt
@@ -7,6 +7,7 @@ module testdata.tld/util
 
 -- enabled/.gunkconfig --
 [generate go]
+plugins=grpc
 json_tag_postproc=true
 
 -- disabled/.gunkconfig --
@@ -19,6 +20,11 @@ package test
 type Person struct {
 	FirstName string `pb:"1" json:"first_name"`
 	LastName string `pb:"2" json:"last_name"`
+}
+
+// AnExampleService is just an example.
+type AnExampleService interface {
+    Example(Person) Person
 }
 
 -- disabled/echo.gunk --


### PR DESCRIPTION
When post process json tag, skipping struct field with no tag defined.