### PR TITLE
docgen: better enum descriptions

### DIFF
--- a/docgen/parser/parser.go
+++ b/docgen/parser/parser.go
@@ -136,19 +136,30 @@ func parseEnums(pkgName string, comments map[string]*Comment, enums []*google_pr
 		res[getQualifiedName(pkgName, e.GetName())] = &Enum{
 			Name:    e.GetName(),
 			Comment: nonNilComment(comments[p]),
-			Values:  parseValues(p, comments, e.GetValue()),
+			Values:  parseValues(p, comments, e.GetValue(), e.GetName()),
 		}
 	}
 	return res
 }
 
-func parseValues(path string, comments map[string]*Comment, values []*google_protobuf.EnumValueDescriptorProto) []*Value {
+func parseValues(
+	path string,
+	comments map[string]*Comment,
+	values []*google_protobuf.EnumValueDescriptorProto,
+	typeName string,
+) []*Value {
 	res := make([]*Value, 0, len(values))
 	for i, v := range values {
 		if v.GetName() != "_" {
+
+			p := fmt.Sprintf("%s.%d.%d", path, fieldFlag, i)
+			comment := comments[p]
+			comment = nonNilComment(comment)
+			comment.Leading = strings.TrimPrefix(comment.Leading, typeName+"_")
+
 			res = append(res, &Value{
 				Name:    v.GetName(),
-				Comment: nonNilComment(comments[fmt.Sprintf("%s.%d.%d", path, fieldFlag, i)]),
+				Comment: comment,
 			})
 		}
 	}

--- a/testdata/scripts/extract.txt
+++ b/testdata/scripts/extract.txt
@@ -462,12 +462,6 @@ msgstr ""
 msgid "EntityType describes the type of the entity."
 msgstr ""
 
-msgid "EntityType_Org is an organisation customer."
-msgstr ""
-
-msgid "EntityType_Pers is an individual customer."
-msgstr ""
-
 msgid "HTTP Request"
 msgstr ""
 
@@ -486,10 +480,16 @@ msgstr ""
 msgid "Objects"
 msgstr ""
 
+msgid "Org is an organisation customer."
+msgstr ""
+
 msgid "OwnerName is the name of the account's owner."
 msgstr ""
 
 msgid "Permanently delete an account."
+msgstr ""
+
+msgid "Pers is an individual customer."
 msgstr ""
 
 msgid "Provides CRUD operations on the accounts resource."
@@ -914,7 +914,7 @@ Annex
 
 EntityType describes the type of the entity.
 
-| Value | Description                                 |
-|-------|---------------------------------------------|
-| Pers  | EntityType_Pers is an individual customer.  |
-| Org   | EntityType_Org is an organisation customer. |
+| Value | Description                      |
+|-------|----------------------------------|
+| Pers  | Pers is an individual customer.  |
+| Org   | Org is an organisation customer. |

--- a/testdata/scripts/extract_annex.txt
+++ b/testdata/scripts/extract_annex.txt
@@ -100,40 +100,40 @@ msgstr ""
 msgid "Bpi"
 msgstr ""
 
+msgid "Checking account."
+msgstr ""
+
+msgid "CommercialLoan for a business loan account."
+msgstr ""
+
+msgid "ConsumerLoan for a consumer loan account."
+msgstr ""
+
 msgid "Cur is the currency of the amount."
+msgstr ""
+
+msgid "Dep for deposit category."
+msgstr ""
+
+msgid "Loan for loan category."
 msgstr ""
 
 msgid "MajorCategory describes the category of the account."
 msgstr ""
 
-msgid "MajorCategory_Dep for deposit category."
-msgstr ""
-
-msgid "MajorCategory_Loan for loan category."
-msgstr ""
-
 msgid "MajorType describes the type of the account."
 msgstr ""
 
-msgid "MajorType_Checking account."
-msgstr ""
-
-msgid "MajorType_CommercialLoan for a business loan account."
-msgstr ""
-
-msgid "MajorType_ConsumerLoan for a consumer loan account."
-msgstr ""
-
-msgid "MajorType_MortgageLoan for a home loan account."
-msgstr ""
-
-msgid "MajorType_Saving account."
-msgstr ""
-
-msgid "MajorType_TimeDeposit for a time deposit account."
+msgid "MortgageLoan for a home loan account."
 msgstr ""
 
 msgid "Num is the value of the amount."
+msgstr ""
+
+msgid "Saving account."
+msgstr ""
+
+msgid "TimeDeposit for a time deposit account."
 msgstr ""
 -- all.md.golden --
 Annex
@@ -169,21 +169,21 @@ MajorCategory
 
 MajorCategory describes the category of the account.
 
-| Value | Description                             |
-|-------|-----------------------------------------|
-| Dep   | MajorCategory_Dep for deposit category. |
-| Loan  | MajorCategory_Loan for loan category.   |
+| Value | Description               |
+|-------|---------------------------|
+| Dep   | Dep for deposit category. |
+| Loan  | Loan for loan category.   |
 
 MajorType
 ---------
 
 MajorType describes the type of the account.
 
-| Value          | Description                                           |
-|----------------|-------------------------------------------------------|
-| Checking       | MajorType_Checking account.                           |
-| Saving         | MajorType_Saving account.                             |
-| TimeDeposit    | MajorType_TimeDeposit for a time deposit account.     |
-| CommercialLoan | MajorType_CommercialLoan for a business loan account. |
-| MortgageLoan   | MajorType_MortgageLoan for a home loan account.       |
-| ConsumerLoan   | MajorType_ConsumerLoan for a consumer loan account.   |
+| Value          | Description                                 |
+|----------------|---------------------------------------------|
+| Checking       | Checking account.                           |
+| Saving         | Saving account.                             |
+| TimeDeposit    | TimeDeposit for a time deposit account.     |
+| CommercialLoan | CommercialLoan for a business loan account. |
+| MortgageLoan   | MortgageLoan for a home loan account.       |
+| ConsumerLoan   | ConsumerLoan for a consumer loan account.   |

--- a/testdata/scripts/extract_append.txt
+++ b/testdata/scripts/extract_append.txt
@@ -223,16 +223,22 @@ msgstr ""
 msgid "Bpi"
 msgstr ""
 
+msgid "Checking account."
+msgstr ""
+
+msgid "CommercialLoan for a business loan account."
+msgstr ""
+
+msgid "ConsumerLoan for a consumer loan account."
+msgstr ""
+
 msgid "Cur is the currency of the amount."
 msgstr ""
 
+msgid "Dep for deposit category."
+msgstr ""
+
 msgid "EntityType describes the type of the entity."
-msgstr ""
-
-msgid "EntityType_Org is an organisation customer."
-msgstr ""
-
-msgid "EntityType_Pers is an individual customer."
 msgstr ""
 
 msgid "HTTP Request"
@@ -241,37 +247,25 @@ msgstr ""
 msgid "Host"
 msgstr ""
 
+msgid "Loan for loan category."
+msgstr ""
+
 msgid "MajorCategory describes the category of the account."
-msgstr ""
-
-msgid "MajorCategory_Dep for deposit category."
-msgstr ""
-
-msgid "MajorCategory_Loan for loan category."
 msgstr ""
 
 msgid "MajorType describes the type of the account."
 msgstr ""
 
-msgid "MajorType_Checking account."
-msgstr ""
-
-msgid "MajorType_CommercialLoan for a business loan account."
-msgstr ""
-
-msgid "MajorType_ConsumerLoan for a consumer loan account."
-msgstr ""
-
-msgid "MajorType_MortgageLoan for a home loan account."
-msgstr ""
-
-msgid "MajorType_Saving account."
-msgstr ""
-
-msgid "MajorType_TimeDeposit for a time deposit account."
+msgid "MortgageLoan for a home loan account."
 msgstr ""
 
 msgid "Num is the value of the amount."
+msgstr ""
+
+msgid "Org is an organisation customer."
+msgstr ""
+
+msgid "Pers is an individual customer."
 msgstr ""
 
 msgid "Provides CRUD operations on the accounts resource."
@@ -301,10 +295,16 @@ msgstr ""
 msgid "Returned when the resource is not found."
 msgstr ""
 
+msgid "Saving account."
+msgstr ""
+
 msgid "Status is the status of the account."
 msgstr ""
 
 msgid "TODO: add comment."
+msgstr ""
+
+msgid "TimeDeposit for a time deposit account."
 msgstr ""
 
 msgid "USE_YOUR_TOKEN"
@@ -376,10 +376,10 @@ Annex
 
 EntityType describes the type of the entity.
 
-| Value | Description                                 |
-|-------|---------------------------------------------|
-| Pers  | EntityType_Pers is an individual customer.  |
-| Org   | EntityType_Org is an organisation customer. |
+| Value | Description                      |
+|-------|----------------------------------|
+| Pers  | Pers is an individual customer.  |
+| Org   | Org is an organisation customer. |
 
 Annex
 =====
@@ -414,21 +414,21 @@ MajorCategory
 
 MajorCategory describes the category of the account.
 
-| Value | Description                             |
-|-------|-----------------------------------------|
-| Dep   | MajorCategory_Dep for deposit category. |
-| Loan  | MajorCategory_Loan for loan category.   |
+| Value | Description               |
+|-------|---------------------------|
+| Dep   | Dep for deposit category. |
+| Loan  | Loan for loan category.   |
 
 MajorType
 ---------
 
 MajorType describes the type of the account.
 
-| Value          | Description                                           |
-|----------------|-------------------------------------------------------|
-| Checking       | MajorType_Checking account.                           |
-| Saving         | MajorType_Saving account.                             |
-| TimeDeposit    | MajorType_TimeDeposit for a time deposit account.     |
-| CommercialLoan | MajorType_CommercialLoan for a business loan account. |
-| MortgageLoan   | MajorType_MortgageLoan for a home loan account.       |
-| ConsumerLoan   | MajorType_ConsumerLoan for a consumer loan account.   |
+| Value          | Description                                 |
+|----------------|---------------------------------------------|
+| Checking       | Checking account.                           |
+| Saving         | Saving account.                             |
+| TimeDeposit    | TimeDeposit for a time deposit account.     |
+| CommercialLoan | CommercialLoan for a business loan account. |
+| MortgageLoan   | MortgageLoan for a home loan account.       |
+| ConsumerLoan   | ConsumerLoan for a consumer loan account.   |

--- a/testdata/scripts/extract_code_sample.txt
+++ b/testdata/scripts/extract_code_sample.txt
@@ -232,12 +232,6 @@ msgstr ""
 msgid "EntityType describes the type of the entity."
 msgstr ""
 
-msgid "EntityType_Org is an organisation customer."
-msgstr ""
-
-msgid "EntityType_Pers is an individual customer."
-msgstr ""
-
 msgid "HTTP Request"
 msgstr ""
 
@@ -247,7 +241,13 @@ msgstr ""
 msgid "MaturityDate is the maturity date, format is ISO 8601"
 msgstr ""
 
+msgid "Org is an organisation customer."
+msgstr ""
+
 msgid "OwnerName is the name of the account's owner."
+msgstr ""
+
+msgid "Pers is an individual customer."
 msgstr ""
 
 msgid "Provides CRUD operations on the accounts resource."
@@ -401,7 +401,7 @@ Annex
 
 EntityType describes the type of the entity.
 
-| Value | Description                                 |
-|-------|---------------------------------------------|
-| Pers  | EntityType_Pers is an individual customer.  |
-| Org   | EntityType_Org is an organisation customer. |
+| Value | Description                      |
+|-------|----------------------------------|
+| Pers  | Pers is an individual customer.  |
+| Org   | Org is an organisation customer. |

--- a/testdata/scripts/extract_custom_header.txt
+++ b/testdata/scripts/extract_custom_header.txt
@@ -463,12 +463,6 @@ msgstr ""
 msgid "EntityType describes the type of the entity."
 msgstr ""
 
-msgid "EntityType_Org is an organisation customer."
-msgstr ""
-
-msgid "EntityType_Pers is an individual customer."
-msgstr ""
-
 msgid "HTTP Request"
 msgstr ""
 
@@ -487,10 +481,16 @@ msgstr ""
 msgid "Objects"
 msgstr ""
 
+msgid "Org is an organisation customer."
+msgstr ""
+
 msgid "OwnerName is the name of the account's owner."
 msgstr ""
 
 msgid "Permanently delete an account."
+msgstr ""
+
+msgid "Pers is an individual customer."
 msgstr ""
 
 msgid "Provides CRUD operations on the accounts resource."
@@ -915,7 +915,7 @@ Annex
 
 EntityType describes the type of the entity.
 
-| Value | Description                                 |
-|-------|---------------------------------------------|
-| Pers  | EntityType_Pers is an individual customer.  |
-| Org   | EntityType_Org is an organisation customer. |
+| Value | Description                      |
+|-------|----------------------------------|
+| Pers  | Pers is an individual customer.  |
+| Org   | Org is an organisation customer. |

--- a/testdata/scripts/extract_more_schemes.txt
+++ b/testdata/scripts/extract_more_schemes.txt
@@ -465,12 +465,6 @@ msgstr ""
 msgid "EntityType describes the type of the entity."
 msgstr ""
 
-msgid "EntityType_Org is an organisation customer."
-msgstr ""
-
-msgid "EntityType_Pers is an individual customer."
-msgstr ""
-
 msgid "HTTP Request"
 msgstr ""
 
@@ -489,10 +483,16 @@ msgstr ""
 msgid "Objects"
 msgstr ""
 
+msgid "Org is an organisation customer."
+msgstr ""
+
 msgid "OwnerName is the name of the account's owner."
 msgstr ""
 
 msgid "Permanently delete an account."
+msgstr ""
+
+msgid "Pers is an individual customer."
 msgstr ""
 
 msgid "Provides CRUD operations on the accounts resource."
@@ -917,7 +917,7 @@ Annex
 
 EntityType describes the type of the entity.
 
-| Value | Description                                 |
-|-------|---------------------------------------------|
-| Pers  | EntityType_Pers is an individual customer.  |
-| Org   | EntityType_Org is an organisation customer. |
+| Value | Description                      |
+|-------|----------------------------------|
+| Pers  | Pers is an individual customer.  |
+| Org   | Org is an organisation customer. |


### PR DESCRIPTION
Currently, the enum description includes the enum type repeated. Let's remove them.

See testscript changes