### PR TITLE
all: rework the use of test caches in test scripts

### DIFF
--- a/generate/download.go
+++ b/generate/download.go
@@ -34,10 +34,15 @@ func CheckOrDownloadProtoc(path, version string) (string, error) {
 
 	dstPath := path
 	if dstPath == "" {
-		// Get the os specific cache directory.
+		// Get the OS-specific cache directory.
 		cachePath, err := os.UserCacheDir()
 		if err != nil {
 			return "", err
+		}
+		if dir := os.Getenv("GUNK_CACHE_DIR"); dir != "" {
+			// Allow overriding the cache dir entirely. Mainly for
+			// the tests.
+			cachePath = dir
 		}
 		cacheDir := filepath.Join(cachePath, "gunk")
 		if err := os.MkdirAll(cacheDir, 0755); err != nil {

--- a/testdata/scripts/config_protoc.txt
+++ b/testdata/scripts/config_protoc.txt
@@ -1,14 +1,10 @@
 # TODO: use [!net] once it does something useful.
 # See https://github.com/rogpeppe/go-internal/issues/75.
-[short] skip 'requires network access' 
+[short] skip 'requires network access'
 
-# Use a separate $HOME, to not reuse a cached protoc.
-env VHOME=$WORK/protoc_home
-env HOME=$VHOME
-env LocalAppData=$VHOME
-env home=$VHOME
-env CACHEDIR=$VHOME$CACHEPATH
-env XDG_CACHE_HOME=$CACHEDIR
+# Use a separate cache directory, to not reuse a cached protoc.
+env GUNK_CACHE_DIR=$WORK/cache
+! exists $GUNK_CACHE_DIR/gunk
 
 # Specify a valid protoc version.
 #
@@ -16,7 +12,7 @@ env XDG_CACHE_HOME=$CACHEDIR
 # version but since it's overriden by any existing child config
 # (i.e. here and in the succeeding tests) nothing blows up
 gunk generate ./version
-exists $CACHEDIR/gunk/protoc-v3.8.0
+exists $GUNK_CACHE_DIR/gunk/protoc-v3.8.0
 exists version/all.pb.go
 
 # Specify an invalid version
@@ -26,14 +22,14 @@ stderr 'error: downloading protoc: invalid version: invalid'
 
 # Don't specify a path or version
 gunk generate ./noversion
-exists $CACHEDIR/gunk/protoc-v3.9.1 # default version
+exists $GUNK_CACHE_DIR/gunk/protoc-v3.9.1 # default version
 exists noversion/all.pb.go
 
 # Specify the path where the first test's binary was downloaded to,
 # but specify a different version
 # copy the downloaded protoc-v3.8.0 to current directory to make
 # pathversion/.gunkconfig work correctly across OSes
-cp $CACHEDIR/gunk/protoc-v3.8.0 protoc-v3.8.0
+cp $GUNK_CACHE_DIR/gunk/protoc-v3.8.0 protoc-v3.8.0
 ! gunk generate ./pathversion
 stderr 'error: want protoc version "v3.7.0" got "3.8.0"'
 ! exists pathversion/all.pb.go

--- a/testdata/scripts/download.txt
+++ b/testdata/scripts/download.txt
@@ -2,8 +2,9 @@
 # See https://github.com/rogpeppe/go-internal/issues/75.
 [short] skip 'requires network access'
 
-# Use a separate $HOME, to not reuse a cached protoc.
-env HOME=$WORK/home
+# Use a separate cache directory, to not reuse a cached protoc.
+env GUNK_CACHE_DIR=$WORK/cache
+! exists $GUNK_CACHE_DIR/gunk
 
 # Download protoc.
 gunk download protoc -v


### PR DESCRIPTION
We were using .cache/home/ under the root of the repository to speed up
incremental test runs, to avoid re-downloading gunk's dependencies at
every test run.

However, this had the major disadvantage of polluting the git checkout,
and leaving read-only files behind, as the Go cache would also end up
there.

Instead, let the tests use the user's real cache directory by default.
Tests which want to use an empty cache set up their own. To simplify
that in a cross-platform way, add a GUNK_CACHE_DIR environment variable.

Overall, the new approach is simpler and tidier.

Fixes #268.