### PR TITLE
Proper leading spaces for multi-line comments

### DIFF
--- a/generate/generate.go
+++ b/generate/generate.go
@@ -575,13 +575,22 @@ func (g *Generator) addDoc(text string, path ...int32) {
 	if text == "" {
 		return
 	}
+
+	// go's ast.TypeSpec.Doc.Text() trims left-trailing spaces on each line of multi-line comment,
+	// while proto's LeadingComments needs them
+	//
+	// block comments still look bad, but that's not a priority now
+	lines := strings.Split(text, "\n")
+	newText := " " + strings.Join(lines, "\n ")
+	newText = strings.TrimRight(newText, " \n")
+
 	if g.pfile.SourceCodeInfo == nil {
 		g.pfile.SourceCodeInfo = &desc.SourceCodeInfo{}
 	}
 	g.pfile.SourceCodeInfo.Location = append(g.pfile.SourceCodeInfo.Location,
 		&desc.SourceCodeInfo_Location{
 			Path:            path,
-			LeadingComments: proto.String(" " + text),
+			LeadingComments: &newText,
 		},
 	)
 }

--- a/testdata/scripts/extract.txt
+++ b/testdata/scripts/extract.txt
@@ -408,7 +408,7 @@ msgstr ""
 msgid "AccountID is the identifier of the account."
 msgstr ""
 
-msgid "AccountID is the unique identifier of an account.Should not be returned as is."
+msgid "AccountID is the unique identifier of an account. Should not be returned as is."
 msgstr ""
 
 msgid "AccountID is the unique identifier of the account to delete."
@@ -732,25 +732,25 @@ curl -X GET \
 
 #### Response body
 
-| Name                              | Type   | Description                                                                    |
-|-----------------------------------|--------|--------------------------------------------------------------------------------|
-| account_id                        | string | AccountID is the unique identifier of an account.Should not be returned as is. |
-| branch                            | string | TODO: add comment.                                                             |
-| branch_name                       | string | TODO: add comment.                                                             |
-| status                            | string | Status is the status of the account.                                           |
-| accrued_interest_at_maturity_date | string | TODO: add comment.                                                             |
-| available_credit_limit            | string | TODO: add comment.                                                             |
-| checking_interest_rate            | string | TODO: add comment.                                                             |
-| contract_date                     | string | ContractDate is the date of the contract initialization.                       |
-| credit_limit                      | string | CreditLimit is the allowed credit limit.                                       |
-| current_accrued_interest          | string | TODO: add comment.                                                             |
-| current_term                      | string | CurrentTerm is the account validity period.                                    |
-| due_date                          | string | DueDate is the loan maturity date.                                             |
-| interest_rate                     | string | TODO: add comment.                                                             |
-| maturity_date                     | string | MaturityDate is the maturity date, format is ISO 8601                          |
-| next_payment_due_date             | string | TODO: add comment.                                                             |
-| owner_name                        | string | OwnerName is the name of the account's owner.                                  |
-| start_date                        | string | TODO: add comment.                                                             |
+| Name                              | Type   | Description                                                                     |
+|-----------------------------------|--------|---------------------------------------------------------------------------------|
+| account_id                        | string | AccountID is the unique identifier of an account. Should not be returned as is. |
+| branch                            | string | TODO: add comment.                                                              |
+| branch_name                       | string | TODO: add comment.                                                              |
+| status                            | string | Status is the status of the account.                                            |
+| accrued_interest_at_maturity_date | string | TODO: add comment.                                                              |
+| available_credit_limit            | string | TODO: add comment.                                                              |
+| checking_interest_rate            | string | TODO: add comment.                                                              |
+| contract_date                     | string | ContractDate is the date of the contract initialization.                        |
+| credit_limit                      | string | CreditLimit is the allowed credit limit.                                        |
+| current_accrued_interest          | string | TODO: add comment.                                                              |
+| current_term                      | string | CurrentTerm is the account validity period.                                     |
+| due_date                          | string | DueDate is the loan maturity date.                                              |
+| interest_rate                     | string | TODO: add comment.                                                              |
+| maturity_date                     | string | MaturityDate is the maturity date, format is ISO 8601                           |
+| next_payment_due_date             | string | TODO: add comment.                                                              |
+| owner_name                        | string | OwnerName is the name of the account's owner.                                   |
+| start_date                        | string | TODO: add comment.                                                              |
 
 Example:
 
@@ -815,25 +815,25 @@ curl -X GET \
 
 ###### Account
 
-| Name                              | Type   | Description                                                                    |
-|-----------------------------------|--------|--------------------------------------------------------------------------------|
-| account_id                        | string | AccountID is the unique identifier of an account.Should not be returned as is. |
-| branch                            | string | TODO: add comment.                                                             |
-| branch_name                       | string | TODO: add comment.                                                             |
-| status                            | string | Status is the status of the account.                                           |
-| accrued_interest_at_maturity_date | string | TODO: add comment.                                                             |
-| available_credit_limit            | string | TODO: add comment.                                                             |
-| checking_interest_rate            | string | TODO: add comment.                                                             |
-| contract_date                     | string | ContractDate is the date of the contract initialization.                       |
-| credit_limit                      | string | CreditLimit is the allowed credit limit.                                       |
-| current_accrued_interest          | string | TODO: add comment.                                                             |
-| current_term                      | string | CurrentTerm is the account validity period.                                    |
-| due_date                          | string | DueDate is the loan maturity date.                                             |
-| interest_rate                     | string | TODO: add comment.                                                             |
-| maturity_date                     | string | MaturityDate is the maturity date, format is ISO 8601                          |
-| next_payment_due_date             | string | TODO: add comment.                                                             |
-| owner_name                        | string | OwnerName is the name of the account's owner.                                  |
-| start_date                        | string | TODO: add comment.                                                             |
+| Name                              | Type   | Description                                                                     |
+|-----------------------------------|--------|---------------------------------------------------------------------------------|
+| account_id                        | string | AccountID is the unique identifier of an account. Should not be returned as is. |
+| branch                            | string | TODO: add comment.                                                              |
+| branch_name                       | string | TODO: add comment.                                                              |
+| status                            | string | Status is the status of the account.                                            |
+| accrued_interest_at_maturity_date | string | TODO: add comment.                                                              |
+| available_credit_limit            | string | TODO: add comment.                                                              |
+| checking_interest_rate            | string | TODO: add comment.                                                              |
+| contract_date                     | string | ContractDate is the date of the contract initialization.                        |
+| credit_limit                      | string | CreditLimit is the allowed credit limit.                                        |
+| current_accrued_interest          | string | TODO: add comment.                                                              |
+| current_term                      | string | CurrentTerm is the account validity period.                                     |
+| due_date                          | string | DueDate is the loan maturity date.                                              |
+| interest_rate                     | string | TODO: add comment.                                                              |
+| maturity_date                     | string | MaturityDate is the maturity date, format is ISO 8601                           |
+| next_payment_due_date             | string | TODO: add comment.                                                              |
+| owner_name                        | string | OwnerName is the name of the account's owner.                                   |
+| start_date                        | string | TODO: add comment.                                                              |
 
 Example:
 

--- a/testdata/scripts/extract_code_sample.txt
+++ b/testdata/scripts/extract_code_sample.txt
@@ -205,7 +205,7 @@ msgstr  "Project-Id-Version: %s\n"
 		"Content-Type: text/plain; charset=CHARSET\n"
 		"Content-Transfer-Encoding: 8bit\n"
 
-msgid "AccountID is the unique identifier of an account.Should not be returned as is."
+msgid "AccountID is the unique identifier of an account. Should not be returned as is."
 msgstr ""
 
 msgid "Accounts API"
@@ -331,25 +331,25 @@ acc, err := c.GetAccount(
 
 #### Response body
 
-| Name                              | Type   | Description                                                                    |
-|-----------------------------------|--------|--------------------------------------------------------------------------------|
-| account_id                        | string | AccountID is the unique identifier of an account.Should not be returned as is. |
-| branch                            | string | TODO: add comment.                                                             |
-| branch_name                       | string | TODO: add comment.                                                             |
-| status                            | string | Status is the status of the account.                                           |
-| accrued_interest_at_maturity_date | string | TODO: add comment.                                                             |
-| available_credit_limit            | string | TODO: add comment.                                                             |
-| checking_interest_rate            | string | TODO: add comment.                                                             |
-| contract_date                     | string | ContractDate is the date of the contract initialization.                       |
-| credit_limit                      | string | CreditLimit is the allowed credit limit.                                       |
-| current_accrued_interest          | string | TODO: add comment.                                                             |
-| current_term                      | string | CurrentTerm is the account validity period.                                    |
-| due_date                          | string | DueDate is the loan maturity date.                                             |
-| interest_rate                     | string | TODO: add comment.                                                             |
-| maturity_date                     | string | MaturityDate is the maturity date, format is ISO 8601                          |
-| next_payment_due_date             | string | TODO: add comment.                                                             |
-| owner_name                        | string | OwnerName is the name of the account's owner.                                  |
-| start_date                        | string | TODO: add comment.                                                             |
+| Name                              | Type   | Description                                                                     |
+|-----------------------------------|--------|---------------------------------------------------------------------------------|
+| account_id                        | string | AccountID is the unique identifier of an account. Should not be returned as is. |
+| branch                            | string | TODO: add comment.                                                              |
+| branch_name                       | string | TODO: add comment.                                                              |
+| status                            | string | Status is the status of the account.                                            |
+| accrued_interest_at_maturity_date | string | TODO: add comment.                                                              |
+| available_credit_limit            | string | TODO: add comment.                                                              |
+| checking_interest_rate            | string | TODO: add comment.                                                              |
+| contract_date                     | string | ContractDate is the date of the contract initialization.                        |
+| credit_limit                      | string | CreditLimit is the allowed credit limit.                                        |
+| current_accrued_interest          | string | TODO: add comment.                                                              |
+| current_term                      | string | CurrentTerm is the account validity period.                                     |
+| due_date                          | string | DueDate is the loan maturity date.                                              |
+| interest_rate                     | string | TODO: add comment.                                                              |
+| maturity_date                     | string | MaturityDate is the maturity date, format is ISO 8601                           |
+| next_payment_due_date             | string | TODO: add comment.                                                              |
+| owner_name                        | string | OwnerName is the name of the account's owner.                                   |
+| start_date                        | string | TODO: add comment.                                                              |
 
 Example:
 

--- a/testdata/scripts/extract_custom_header.txt
+++ b/testdata/scripts/extract_custom_header.txt
@@ -409,7 +409,7 @@ msgstr ""
 msgid "AccountID is the identifier of the account."
 msgstr ""
 
-msgid "AccountID is the unique identifier of an account.Should not be returned as is."
+msgid "AccountID is the unique identifier of an account. Should not be returned as is."
 msgstr ""
 
 msgid "AccountID is the unique identifier of the account to delete."
@@ -733,25 +733,25 @@ curl -X GET \
 
 #### Response body {#response-body-method-get-getaccount}
 
-| Name                              | Type   | Description                                                                    |
-|-----------------------------------|--------|--------------------------------------------------------------------------------|
-| account_id                        | string | AccountID is the unique identifier of an account.Should not be returned as is. |
-| branch                            | string | TODO: add comment.                                                             |
-| branch_name                       | string | TODO: add comment.                                                             |
-| status                            | string | Status is the status of the account.                                           |
-| accrued_interest_at_maturity_date | string | TODO: add comment.                                                             |
-| available_credit_limit            | string | TODO: add comment.                                                             |
-| checking_interest_rate            | string | TODO: add comment.                                                             |
-| contract_date                     | string | ContractDate is the date of the contract initialization.                       |
-| credit_limit                      | string | CreditLimit is the allowed credit limit.                                       |
-| current_accrued_interest          | string | TODO: add comment.                                                             |
-| current_term                      | string | CurrentTerm is the account validity period.                                    |
-| due_date                          | string | DueDate is the loan maturity date.                                             |
-| interest_rate                     | string | TODO: add comment.                                                             |
-| maturity_date                     | string | MaturityDate is the maturity date, format is ISO 8601                          |
-| next_payment_due_date             | string | TODO: add comment.                                                             |
-| owner_name                        | string | OwnerName is the name of the account's owner.                                  |
-| start_date                        | string | TODO: add comment.                                                             |
+| Name                              | Type   | Description                                                                     |
+|-----------------------------------|--------|---------------------------------------------------------------------------------|
+| account_id                        | string | AccountID is the unique identifier of an account. Should not be returned as is. |
+| branch                            | string | TODO: add comment.                                                              |
+| branch_name                       | string | TODO: add comment.                                                              |
+| status                            | string | Status is the status of the account.                                            |
+| accrued_interest_at_maturity_date | string | TODO: add comment.                                                              |
+| available_credit_limit            | string | TODO: add comment.                                                              |
+| checking_interest_rate            | string | TODO: add comment.                                                              |
+| contract_date                     | string | ContractDate is the date of the contract initialization.                        |
+| credit_limit                      | string | CreditLimit is the allowed credit limit.                                        |
+| current_accrued_interest          | string | TODO: add comment.                                                              |
+| current_term                      | string | CurrentTerm is the account validity period.                                     |
+| due_date                          | string | DueDate is the loan maturity date.                                              |
+| interest_rate                     | string | TODO: add comment.                                                              |
+| maturity_date                     | string | MaturityDate is the maturity date, format is ISO 8601                           |
+| next_payment_due_date             | string | TODO: add comment.                                                              |
+| owner_name                        | string | OwnerName is the name of the account's owner.                                   |
+| start_date                        | string | TODO: add comment.                                                              |
 
 Example:
 
@@ -816,25 +816,25 @@ curl -X GET \
 
 ###### Account
 
-| Name                              | Type   | Description                                                                    |
-|-----------------------------------|--------|--------------------------------------------------------------------------------|
-| account_id                        | string | AccountID is the unique identifier of an account.Should not be returned as is. |
-| branch                            | string | TODO: add comment.                                                             |
-| branch_name                       | string | TODO: add comment.                                                             |
-| status                            | string | Status is the status of the account.                                           |
-| accrued_interest_at_maturity_date | string | TODO: add comment.                                                             |
-| available_credit_limit            | string | TODO: add comment.                                                             |
-| checking_interest_rate            | string | TODO: add comment.                                                             |
-| contract_date                     | string | ContractDate is the date of the contract initialization.                       |
-| credit_limit                      | string | CreditLimit is the allowed credit limit.                                       |
-| current_accrued_interest          | string | TODO: add comment.                                                             |
-| current_term                      | string | CurrentTerm is the account validity period.                                    |
-| due_date                          | string | DueDate is the loan maturity date.                                             |
-| interest_rate                     | string | TODO: add comment.                                                             |
-| maturity_date                     | string | MaturityDate is the maturity date, format is ISO 8601                          |
-| next_payment_due_date             | string | TODO: add comment.                                                             |
-| owner_name                        | string | OwnerName is the name of the account's owner.                                  |
-| start_date                        | string | TODO: add comment.                                                             |
+| Name                              | Type   | Description                                                                     |
+|-----------------------------------|--------|---------------------------------------------------------------------------------|
+| account_id                        | string | AccountID is the unique identifier of an account. Should not be returned as is. |
+| branch                            | string | TODO: add comment.                                                              |
+| branch_name                       | string | TODO: add comment.                                                              |
+| status                            | string | Status is the status of the account.                                            |
+| accrued_interest_at_maturity_date | string | TODO: add comment.                                                              |
+| available_credit_limit            | string | TODO: add comment.                                                              |
+| checking_interest_rate            | string | TODO: add comment.                                                              |
+| contract_date                     | string | ContractDate is the date of the contract initialization.                        |
+| credit_limit                      | string | CreditLimit is the allowed credit limit.                                        |
+| current_accrued_interest          | string | TODO: add comment.                                                              |
+| current_term                      | string | CurrentTerm is the account validity period.                                     |
+| due_date                          | string | DueDate is the loan maturity date.                                              |
+| interest_rate                     | string | TODO: add comment.                                                              |
+| maturity_date                     | string | MaturityDate is the maturity date, format is ISO 8601                           |
+| next_payment_due_date             | string | TODO: add comment.                                                              |
+| owner_name                        | string | OwnerName is the name of the account's owner.                                   |
+| start_date                        | string | TODO: add comment.                                                              |
 
 Example:
 

--- a/testdata/scripts/extract_more_schemes.txt
+++ b/testdata/scripts/extract_more_schemes.txt
@@ -411,7 +411,7 @@ msgstr ""
 msgid "AccountID is the identifier of the account."
 msgstr ""
 
-msgid "AccountID is the unique identifier of an account.Should not be returned as is."
+msgid "AccountID is the unique identifier of an account. Should not be returned as is."
 msgstr ""
 
 msgid "AccountID is the unique identifier of the account to delete."
@@ -735,25 +735,25 @@ curl -X GET \
 
 #### Response body
 
-| Name                              | Type   | Description                                                                    |
-|-----------------------------------|--------|--------------------------------------------------------------------------------|
-| account_id                        | string | AccountID is the unique identifier of an account.Should not be returned as is. |
-| branch                            | string | TODO: add comment.                                                             |
-| branch_name                       | string | TODO: add comment.                                                             |
-| status                            | string | Status is the status of the account.                                           |
-| accrued_interest_at_maturity_date | string | TODO: add comment.                                                             |
-| available_credit_limit            | string | TODO: add comment.                                                             |
-| checking_interest_rate            | string | TODO: add comment.                                                             |
-| contract_date                     | string | ContractDate is the date of the contract initialization.                       |
-| credit_limit                      | string | CreditLimit is the allowed credit limit.                                       |
-| current_accrued_interest          | string | TODO: add comment.                                                             |
-| current_term                      | string | CurrentTerm is the account validity period.                                    |
-| due_date                          | string | DueDate is the loan maturity date.                                             |
-| interest_rate                     | string | TODO: add comment.                                                             |
-| maturity_date                     | string | MaturityDate is the maturity date, format is ISO 8601                          |
-| next_payment_due_date             | string | TODO: add comment.                                                             |
-| owner_name                        | string | OwnerName is the name of the account's owner.                                  |
-| start_date                        | string | TODO: add comment.                                                             |
+| Name                              | Type   | Description                                                                     |
+|-----------------------------------|--------|---------------------------------------------------------------------------------|
+| account_id                        | string | AccountID is the unique identifier of an account. Should not be returned as is. |
+| branch                            | string | TODO: add comment.                                                              |
+| branch_name                       | string | TODO: add comment.                                                              |
+| status                            | string | Status is the status of the account.                                            |
+| accrued_interest_at_maturity_date | string | TODO: add comment.                                                              |
+| available_credit_limit            | string | TODO: add comment.                                                              |
+| checking_interest_rate            | string | TODO: add comment.                                                              |
+| contract_date                     | string | ContractDate is the date of the contract initialization.                        |
+| credit_limit                      | string | CreditLimit is the allowed credit limit.                                        |
+| current_accrued_interest          | string | TODO: add comment.                                                              |
+| current_term                      | string | CurrentTerm is the account validity period.                                     |
+| due_date                          | string | DueDate is the loan maturity date.                                              |
+| interest_rate                     | string | TODO: add comment.                                                              |
+| maturity_date                     | string | MaturityDate is the maturity date, format is ISO 8601                           |
+| next_payment_due_date             | string | TODO: add comment.                                                              |
+| owner_name                        | string | OwnerName is the name of the account's owner.                                   |
+| start_date                        | string | TODO: add comment.                                                              |
 
 Example:
 
@@ -818,25 +818,25 @@ curl -X GET \
 
 ###### Account
 
-| Name                              | Type   | Description                                                                    |
-|-----------------------------------|--------|--------------------------------------------------------------------------------|
-| account_id                        | string | AccountID is the unique identifier of an account.Should not be returned as is. |
-| branch                            | string | TODO: add comment.                                                             |
-| branch_name                       | string | TODO: add comment.                                                             |
-| status                            | string | Status is the status of the account.                                           |
-| accrued_interest_at_maturity_date | string | TODO: add comment.                                                             |
-| available_credit_limit            | string | TODO: add comment.                                                             |
-| checking_interest_rate            | string | TODO: add comment.                                                             |
-| contract_date                     | string | ContractDate is the date of the contract initialization.                       |
-| credit_limit                      | string | CreditLimit is the allowed credit limit.                                       |
-| current_accrued_interest          | string | TODO: add comment.                                                             |
-| current_term                      | string | CurrentTerm is the account validity period.                                    |
-| due_date                          | string | DueDate is the loan maturity date.                                             |
-| interest_rate                     | string | TODO: add comment.                                                             |
-| maturity_date                     | string | MaturityDate is the maturity date, format is ISO 8601                          |
-| next_payment_due_date             | string | TODO: add comment.                                                             |
-| owner_name                        | string | OwnerName is the name of the account's owner.                                  |
-| start_date                        | string | TODO: add comment.                                                             |
+| Name                              | Type   | Description                                                                     |
+|-----------------------------------|--------|---------------------------------------------------------------------------------|
+| account_id                        | string | AccountID is the unique identifier of an account. Should not be returned as is. |
+| branch                            | string | TODO: add comment.                                                              |
+| branch_name                       | string | TODO: add comment.                                                              |
+| status                            | string | Status is the status of the account.                                            |
+| accrued_interest_at_maturity_date | string | TODO: add comment.                                                              |
+| available_credit_limit            | string | TODO: add comment.                                                              |
+| checking_interest_rate            | string | TODO: add comment.                                                              |
+| contract_date                     | string | ContractDate is the date of the contract initialization.                        |
+| credit_limit                      | string | CreditLimit is the allowed credit limit.                                        |
+| current_accrued_interest          | string | TODO: add comment.                                                              |
+| current_term                      | string | CurrentTerm is the account validity period.                                     |
+| due_date                          | string | DueDate is the loan maturity date.                                              |
+| interest_rate                     | string | TODO: add comment.                                                              |
+| maturity_date                     | string | MaturityDate is the maturity date, format is ISO 8601                           |
+| next_payment_due_date             | string | TODO: add comment.                                                              |
+| owner_name                        | string | OwnerName is the name of the account's owner.                                   |
+| start_date                        | string | TODO: add comment.                                                              |
 
 Example:
 

--- a/testdata/scripts/generate_go_comments.txt
+++ b/testdata/scripts/generate_go_comments.txt
@@ -1,0 +1,22 @@
+gunk generate -v ./...
+grep '\/\/ with a space' all.pb.go
+grep '\/\/ without a space' all.pb.go
+
+-- go.mod --
+module testdata.tld/util
+
+-- .gunkconfig --
+[generate go]
+
+-- echo.gunk --
+package test
+
+type Person struct {
+	// Comment
+	// with a space
+	Name string `pb:"1"`
+
+	//Comment
+	//without a space
+	Surname string `pb:"2"`
+}


### PR DESCRIPTION
go's ast.TypeSpec.Doc.Text() trims left-trailing spaces on each line of multi-line comment,
while proto's LeadingComments needs them

block comments still look bad, but that's not a priority now

Fixes https://github.com/gunk/gunk/issues/310