### PR TITLE
Make .pb.go deterministic by deterministic marshal

### DIFF
--- a/dump/dump.go
+++ b/dump/dump.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/gunk/gunk/generate"
+	"github.com/gunk/gunk/protoutil"
 )
 
 // Run will generate the FileDescriptorSet for a Gunk package, and
@@ -29,7 +29,7 @@ func Run(format, dir string, patterns ...string) error {
 		}
 	case "", "proto":
 		// The default format.
-		bs, err = proto.Marshal(fds)
+		bs, err = protoutil.MarshalDeterministic(fds)
 		if err != nil {
 			return err
 		}

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gunk/gunk/config"
 	"github.com/gunk/gunk/loader"
 	"github.com/gunk/gunk/log"
+	"github.com/gunk/gunk/protoutil"
 	"github.com/gunk/gunk/reflectutil"
 )
 
@@ -238,7 +239,7 @@ func (g *Generator) generateProtoc(req plugin.CodeGeneratorRequest, gen config.G
 		protocOutputPath = gpkg.Dir
 	}
 
-	bs, err := proto.Marshal(fds)
+	bs, err := protoutil.MarshalDeterministic(fds)
 	if err != nil {
 		return err
 	}
@@ -274,7 +275,7 @@ func (g *Generator) generatePlugin(req plugin.CodeGeneratorRequest, gen config.G
 		}
 		req.Parameter = proto.String(ps)
 	}
-	bs, err := proto.Marshal(&req)
+	bs, err := protoutil.MarshalDeterministic(&req)
 	if err != nil {
 		return err
 	}

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	plugin_go "github.com/golang/protobuf/protoc-gen-go/plugin"
+
+	"github.com/gunk/gunk/protoutil"
 )
 
 // Plugin provides plugin method.
@@ -53,7 +55,7 @@ func readRequest(r io.Reader) (*plugin_go.CodeGeneratorRequest, error) {
 }
 
 func writeResponse(w io.Writer, resp *plugin_go.CodeGeneratorResponse) error {
-	data, err := proto.Marshal(resp)
+	data, err := protoutil.MarshalDeterministic(resp)
 	if err != nil {
 		return err
 	}

--- a/protoutil/marshal.go
+++ b/protoutil/marshal.go
@@ -1,0 +1,15 @@
+package protoutil
+
+import (
+	"github.com/golang/protobuf/proto"
+)
+
+func MarshalDeterministic(pb proto.Message) ([]byte, error) {
+	buffer := proto.NewBuffer(nil)
+	buffer.SetDeterministic(true)
+
+	if err := buffer.Marshal(pb); err != nil {
+		return nil, err
+	}
+	return buffer.Bytes(), nil
+}

--- a/testdata/protoc-gen-strict/main.go
+++ b/testdata/protoc-gen-strict/main.go
@@ -8,6 +8,8 @@ import (
 	"io/ioutil"
 	"os"
 
+	"github.com/gunk/gunk/protoutil"
+
 	"github.com/golang/protobuf/proto"
 	desc "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	plugin "github.com/golang/protobuf/protoc-gen-go/plugin"
@@ -26,7 +28,7 @@ func main() {
 		panic(err)
 	}
 	var resp plugin.CodeGeneratorResponse
-	output, err := proto.Marshal(&resp)
+	output, err := protoutil.MarshalDeterministic(&resp)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
We have large diffs in generated .pb.go files even when there is no change in the protobuf itself. Example:

https://github.com/openbank/openbank/commit/1535696c0f58698898b266dee9bbd4ff144dc874#diff-790a2e5fdb0867ef31e92c5b78946f3c

I found out it's actually caused by non-deterministic marshaling of maps; by default, proto.Marshal is non-deterministic with maps, and grpc uses maps to save response types.

If you actually un-gzip the byte array and diff the filedescriptor, the only changes are in the order of the maps in GRPC.

You can marshal deterministcally using proto.Buffer, so I added a helper func that does that