### PR TITLE
Fixes after protobuf updates

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -24,11 +24,12 @@ type KeyValue struct {
 }
 
 type Generator struct {
-	ProtocGen string // The type of protoc generator that should be run; js, python, etc.
-	Command   string
-	Params    []KeyValue
-	ConfigDir string
-	Out       string
+	ProtocGen      string // The type of protoc generator that should be run; js, python, etc.
+	Command        string
+	Params         []KeyValue
+	PostProcParams []KeyValue
+	ConfigDir      string
+	Out            string
 }
 
 func (g Generator) IsProtoc() bool {
@@ -272,7 +273,11 @@ func handleGenerate(section *parser.Section) (*Generator, error) {
 		case "out":
 			gen.Out = v
 		default:
-			gen.Params = append(gen.Params, KeyValue{k, v})
+			if strings.HasSuffix(k, "postproc") {
+				gen.PostProcParams = append(gen.Params, KeyValue{k, v})
+			} else {
+				gen.Params = append(gen.Params, KeyValue{k, v})
+			}
 		}
 	}
 	return gen, nil

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -270,9 +270,6 @@ func (g *Generator) generatePlugin(req plugin.CodeGeneratorRequest, gen config.G
 	// Due to problems with some generators (grpc-gateway),
 	// we need to ensure we either send a non-empty string or nil.
 	if ps := gen.ParamString(); ps != "" {
-		if gen.Out != "" {
-			ps += fmt.Sprintf(",out=%s", gen.Out)
-		}
 		req.Parameter = proto.String(ps)
 	}
 	bs, err := protoutil.MarshalDeterministic(&req)

--- a/generate/post_process.go
+++ b/generate/post_process.go
@@ -6,9 +6,9 @@ import (
 	"github.com/gunk/gunk/config"
 )
 
-// parseBoolParam returns true if the given parameter name exists and is a truthful value.
-func parseBoolParam(paramName string, gen config.Generator) (bool, error) {
-	for _, param := range gen.Params {
+// parsePostProcBoolParam returns true if the given parameter name exists and is a truthful value.
+func parsePostProcBoolParam(paramName string, gen config.Generator) (bool, error) {
+	for _, param := range gen.PostProcParams {
 		if param.Key == paramName {
 			result, err := strconv.ParseBool(param.Value)
 			if err != nil {
@@ -29,7 +29,7 @@ func postProcess(input []byte, gen config.Generator) ([]byte, error) {
 
 	switch gen.Command {
 	case protocGenGoCmd:
-		jsonTagPostprocEnabled, err := parseBoolParam(jsonTagPostprocParamName, gen)
+		jsonTagPostprocEnabled, err := parsePostProcBoolParam(jsonTagPostprocParamName, gen)
 		if err != nil {
 			return nil, err
 		}

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/bmatcuk/doublestar v1.3.4 // indirect
 	github.com/emicklei/proto v1.9.0
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
-	github.com/gogo/protobuf v1.3.1
 	github.com/golang/protobuf v1.4.3
 	github.com/google/go-cmp v0.5.4 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
@@ -32,7 +31,7 @@ require (
 	golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb // indirect
 	golang.org/x/sys v0.0.0-20201202213521-69691e467435 // indirect
 	golang.org/x/text v0.3.4 // indirect
-	golang.org/x/tools v0.0.0-20201203202102-a1a1cbeaa516
+	golang.org/x/tools v0.0.0-20210106214847-113979e3529a
 	google.golang.org/genproto v0.0.0-20201203001206-6486ece9c497
 	google.golang.org/grpc v1.34.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6

--- a/go.sum
+++ b/go.sum
@@ -79,8 +79,6 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1 h1:/s5zKNz0uPFCZ5hddgPdo2TK2TVrUNMn0OOX8/aZMTE=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
-github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
-github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -164,7 +162,6 @@ github.com/kenshaw/ini v0.5.0/go.mod h1:v5uWwqgB77QUIdF3wryBIhlcXBVsWQZ2ScH5HY6q
 github.com/kenshaw/snaker v0.1.0 h1:h6dvdkBw6Qe1ya/LE9kMa9Y8M3RSAhbELfirZHIFobU=
 github.com/kenshaw/snaker v0.1.0/go.mod h1:0xAAdPB2IwUAxxUZj5ZvPclku2HJBSB7TRcJxvhVwM8=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
-github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
@@ -393,7 +390,6 @@ golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxb
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
-golang.org/x/tools v0.0.0-20181030221726-6c7e314b6563/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
@@ -412,8 +408,8 @@ golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191112195655-aa38f8e97acc/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20201121010211-780cb80bd7fb/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
-golang.org/x/tools v0.0.0-20201203202102-a1a1cbeaa516 h1:E8xavSjXY8LFvcMSu/8Fjztt+SerwKnuAUOdS+aCXUM=
-golang.org/x/tools v0.0.0-20201203202102-a1a1cbeaa516/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools v0.0.0-20210106214847-113979e3529a h1:CB3a9Nez8M13wwlr/E2YtwoU+qYHKfC+JrDa45RXXoQ=
+golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -6,7 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/gogo/protobuf/proto"
+	"github.com/golang/protobuf/proto"
 	plugin_go "github.com/golang/protobuf/protoc-gen-go/plugin"
 
 	"github.com/gunk/gunk/protoutil"

--- a/scopegen/scopegen.go
+++ b/scopegen/scopegen.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/gogo/protobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/golang/protobuf/protoc-gen-go/plugin"
 

--- a/testdata/scripts/config_protoc.txt
+++ b/testdata/scripts/config_protoc.txt
@@ -7,17 +7,13 @@ env GUNK_CACHE_DIR=$WORK/cache
 ! exists $GUNK_CACHE_DIR/gunk
 
 # Specify a valid protoc version.
-#
-# Note that the parent gunkconfig uses an invalid
-# version but since it's overriden by any existing child config
-# (i.e. here and in the succeeding tests) nothing blows up
 gunk generate ./version
 exists $GUNK_CACHE_DIR/gunk/protoc-v3.8.0
 exists version/all.pb.go
 
 # Specify an invalid version
 ! gunk generate ./badversion
-stderr 'error: downloading protoc: invalid version: invalid'
+stderr 'downloading protoc: invalid version: invalid'
 ! exists badversion/all.pb.go
 
 # Don't specify a path or version
@@ -31,7 +27,7 @@ exists noversion/all.pb.go
 # pathversion/.gunkconfig work correctly across OSes
 cp $GUNK_CACHE_DIR/gunk/protoc-v3.8.0 protoc-v3.8.0
 ! gunk generate ./pathversion
-stderr 'error: want protoc version "v3.7.0" got "3.8.0"'
+stderr 'want protoc version "v3.7.0" got "3.8.0"'
 ! exists pathversion/all.pb.go
 
 -- go.mod --
@@ -39,7 +35,6 @@ module testdata.tld/util
 
 -- .gunkconfig --
 [generate]
-version=ignored
 command=protoc-gen-go
 plugins=grpc
 

--- a/testdata/scripts/extract.txt
+++ b/testdata/scripts/extract.txt
@@ -552,8 +552,7 @@ msgstr ""
 msgid "Updates an account with all the fields supplied."
 msgstr ""
 -- all.md.golden --
-Accounts API v1.0.0
-===================
+# Accounts API v1.0.0
 
 Provides CRUD operations on the accounts resource.
 
@@ -561,8 +560,7 @@ Provides CRUD operations on the accounts resource.
 
 * Base Path `/path`
 
-Create an account
------------------
+## Create an account
 
 Creates a new account
 
@@ -674,8 +672,7 @@ Example:
 | 403    | Returned when the user does not have permission to access the resource.                |
 | 500    | Returned when an unexpected error occured on the server side.                          |
 
-Delete an account
------------------
+## Delete an account
 
 Permanently delete an account.
 
@@ -707,8 +704,7 @@ curl -X DELETE \
 | 403    | Returned when the user does not have permission to access the resource.                |
 | 500    | Returned when an unexpected error occured on the server side.                          |
 
-Retrieve an account
--------------------
+## Retrieve an account
 
 Retrieves all data from an account, selected by the account_id you supplied.
 
@@ -787,8 +783,7 @@ Example:
 | 403    | Returned when the user does not have permission to access the resource.                |
 | 500    | Returned when an unexpected error occured on the server side.                          |
 
-List all accounts
------------------
+## List all accounts
 
 Returns a list containing up to 20 accounts. You can paginate through account by supplying next_starting_index in your subsequents calls. next_starting_index contains the account_id of the last account_id of the current page.
 
@@ -874,8 +869,7 @@ Example:
 | 403    | Returned when the user does not have permission to access the resource.                |
 | 500    | Returned when an unexpected error occured on the server side.                          |
 
-Update an account
------------------
+## Update an account
 
 Updates an account with all the fields supplied.
 

--- a/testdata/scripts/extract_append.txt
+++ b/testdata/scripts/extract_append.txt
@@ -157,15 +157,13 @@ msgstr ""
 msgid "USE_YOUR_TOKEN"
 msgstr ""
 -- all.md.golden --
-First API v1.0.0
-================
+# First API v1.0.0
 
 * Host `https://openbank.com`
 
 * Base Path `/path`
 
-Gets foo
---------
+## Gets foo
 
 ```sh
 curl -X GET \
@@ -199,15 +197,13 @@ Example:
 |--------|-------------|
 | 200    |             |
 
-Second API v1.0.0
-=================
+# Second API v1.0.0
 
 * Host `https://openbank.com`
 
 * Base Path `/path`
 
-Gets baz
---------
+## Gets baz
 
 ```sh
 curl -X GET \

--- a/testdata/scripts/extract_code_sample.txt
+++ b/testdata/scripts/extract_code_sample.txt
@@ -274,8 +274,7 @@ msgstr ""
 msgid "USE_YOUR_TOKEN"
 msgstr ""
 -- all.md.golden --
-Accounts API v1.0.0
-===================
+# Accounts API v1.0.0
 
 Provides CRUD operations on the accounts resource.
 
@@ -283,8 +282,7 @@ Provides CRUD operations on the accounts resource.
 
 * Base Path `/path`
 
-Retrieve an account
--------------------
+## Retrieve an account
 
 Retrieves all data from an account, selected by the account_id you supplied.
 

--- a/testdata/scripts/extract_custom_header.txt
+++ b/testdata/scripts/extract_custom_header.txt
@@ -553,8 +553,7 @@ msgstr ""
 msgid "Updates an account with all the fields supplied."
 msgstr ""
 -- all.md.golden --
-Accounts API v1.0.0
-===================
+# Accounts API v1.0.0
 
 Provides CRUD operations on the accounts resource.
 
@@ -562,8 +561,7 @@ Provides CRUD operations on the accounts resource.
 
 * Base Path `/path`
 
-Create an account {#method-post-createaccount}
-----------------------------------------------
+## Create an account {#method-post-createaccount}
 
 Creates a new account
 
@@ -675,8 +673,7 @@ Example:
 | 403    | Returned when the user does not have permission to access the resource.                |
 | 500    | Returned when an unexpected error occured on the server side.                          |
 
-Delete an account {#method-delete-deleteaccount}
-------------------------------------------------
+## Delete an account {#method-delete-deleteaccount}
 
 Permanently delete an account.
 
@@ -708,8 +705,7 @@ curl -X DELETE \
 | 403    | Returned when the user does not have permission to access the resource.                |
 | 500    | Returned when an unexpected error occured on the server side.                          |
 
-Retrieve an account {#method-get-getaccount}
---------------------------------------------
+## Retrieve an account {#method-get-getaccount}
 
 Retrieves all data from an account, selected by the account_id you supplied.
 
@@ -788,8 +784,7 @@ Example:
 | 403    | Returned when the user does not have permission to access the resource.                |
 | 500    | Returned when an unexpected error occured on the server side.                          |
 
-List all accounts {#method-get-getaccounts}
--------------------------------------------
+## List all accounts {#method-get-getaccounts}
 
 Returns a list containing up to 20 accounts. You can paginate through account by supplying next_starting_index in your subsequents calls. next_starting_index contains the account_id of the last account_id of the current page.
 
@@ -875,8 +870,7 @@ Example:
 | 403    | Returned when the user does not have permission to access the resource.                |
 | 500    | Returned when an unexpected error occured on the server side.                          |
 
-Update an account {#method-put-updateaccount}
----------------------------------------------
+## Update an account {#method-put-updateaccount}
 
 Updates an account with all the fields supplied.
 

--- a/testdata/scripts/extract_import.txt
+++ b/testdata/scripts/extract_import.txt
@@ -72,15 +72,13 @@ type Amount struct {
 	Num string `pb:"2" json:"num"`
 }
 -- accounts/all.md.golden --
-Accounts API v1.0.0
-===================
+# Accounts API v1.0.0
 
 * Host `https://openbank.com`
 
 * Base Path `/path`
 
-Retrieve an account
--------------------
+## Retrieve an account
 
 ```sh
 curl -X GET \

--- a/testdata/scripts/extract_more_schemes.txt
+++ b/testdata/scripts/extract_more_schemes.txt
@@ -555,8 +555,7 @@ msgstr ""
 msgid "Updates an account with all the fields supplied."
 msgstr ""
 -- all.md.golden --
-Accounts API v1.0.0
-===================
+# Accounts API v1.0.0
 
 Provides CRUD operations on the accounts resource.
 
@@ -564,8 +563,7 @@ Provides CRUD operations on the accounts resource.
 
 * Base Path `/path`
 
-Create an account
------------------
+## Create an account
 
 Creates a new account
 
@@ -677,8 +675,7 @@ Example:
 | 403    | Returned when the user does not have permission to access the resource.                |
 | 500    | Returned when an unexpected error occured on the server side.                          |
 
-Delete an account
------------------
+## Delete an account
 
 Permanently delete an account.
 
@@ -710,8 +707,7 @@ curl -X DELETE \
 | 403    | Returned when the user does not have permission to access the resource.                |
 | 500    | Returned when an unexpected error occured on the server side.                          |
 
-Retrieve an account
--------------------
+## Retrieve an account
 
 Retrieves all data from an account, selected by the account_id you supplied.
 
@@ -790,8 +786,7 @@ Example:
 | 403    | Returned when the user does not have permission to access the resource.                |
 | 500    | Returned when an unexpected error occured on the server side.                          |
 
-List all accounts
------------------
+## List all accounts
 
 Returns a list containing up to 20 accounts. You can paginate through account by supplying next_starting_index in your subsequents calls. next_starting_index contains the account_id of the last account_id of the current page.
 
@@ -877,8 +872,7 @@ Example:
 | 403    | Returned when the user does not have permission to access the resource.                |
 | 500    | Returned when an unexpected error occured on the server side.                          |
 
-Update an account
------------------
+## Update an account
 
 Updates an account with all the fields supplied.
 

--- a/testdata/scripts/extract_nested.txt
+++ b/testdata/scripts/extract_nested.txt
@@ -135,8 +135,7 @@ type TransactionService interface {
 	CreateTransaction(Transaction) CreateTransactionResponse
 }
 -- all.md.golden --
-Transactions API v1.0.0
-=======================
+# Transactions API v1.0.0
 
 Provides create and read operations on the transaction resource.
 
@@ -144,8 +143,7 @@ Provides create and read operations on the transaction resource.
 
 * Base Path `/path`
 
-Create a transaction
---------------------
+## Create a transaction
 
 Creates a new transaction record
 
@@ -231,8 +229,7 @@ Example:
 |--------|-----------------------------------|
 | 201    | Transaction created successfully. |
 
-Retrieve a transaction
-----------------------
+## Retrieve a transaction
 
 Retrieves all data from a transaction, selected by the `transaction_id` you supplied.
 

--- a/testdata/scripts/extract_nested_enum.txt
+++ b/testdata/scripts/extract_nested_enum.txt
@@ -107,8 +107,7 @@ type TransactionService interface {
 	GetTransaction(GetTransactionRequest) Transaction
 }
 -- transactions/all.md.golden --
-Transactions API v1.0.0
-=======================
+# Transactions API v1.0.0
 
 Provides create and read operations on the transaction resource.
 
@@ -116,8 +115,7 @@ Provides create and read operations on the transaction resource.
 
 * Base Path `/path`
 
-Retrieve a transaction
-----------------------
+## Retrieve a transaction
 
 Retrieves all data from a transaction, selected by the `transaction_id` you supplied.
 

--- a/testdata/scripts/generate_complete_swagger.txt
+++ b/testdata/scripts/generate_complete_swagger.txt
@@ -52,7 +52,7 @@ require (
       "get": {
         "summary": "Retrieves message",
         "description": "Get message",
-        "operationId": "GetMessage",
+        "operationId": "Service_GetMessage",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -67,12 +67,14 @@ require (
           "404": {
             "description": "Returned when the resource does not exist.",
             "schema": {
+              "type": "string",
               "format": "string"
             }
           },
           "418": {
             "description": "I'm a teapot.",
             "schema": {
+              "type": "string",
               "$ref": ".grpc.gateway.examples.examplepb.NumericEnum",
               "title": "my title",
               "externalDocs": {
@@ -97,6 +99,12 @@ require (
                 "date"
               ]
             }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/runtimeError"
+            }
           }
         },
         "parameters": [
@@ -120,6 +128,39 @@ require (
     }
   },
   "definitions": {
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "type_url": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string",
+          "format": "byte"
+        }
+      }
+    },
+    "runtimeError": {
+      "type": "object",
+      "properties": {
+        "error": {
+          "type": "string"
+        },
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    },
     "testMessage": {
       "type": "object",
       "properties": {
@@ -204,11 +245,11 @@ json_names_for_fields=true
     "application/x-foo-mime"
   ],
   "paths": {
-    "/v1/message/{Name}": {
+    "/v1/message/{name}": {
       "get": {
         "summary": "Retrieves message",
         "description": "Get message",
-        "operationId": "GetMessage",
+        "operationId": "Service_GetMessage",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -223,12 +264,14 @@ json_names_for_fields=true
           "404": {
             "description": "Returned when the resource does not exist.",
             "schema": {
+              "type": "string",
               "format": "string"
             }
           },
           "418": {
             "description": "I'm a teapot.",
             "schema": {
+              "type": "string",
               "$ref": ".grpc.gateway.examples.examplepb.NumericEnum",
               "title": "my title",
               "externalDocs": {
@@ -253,11 +296,17 @@ json_names_for_fields=true
                 "date"
               ]
             }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/runtimeError"
+            }
           }
         },
         "parameters": [
           {
-            "name": "Name",
+            "name": "name",
             "in": "path",
             "required": true,
             "type": "string"
@@ -276,6 +325,39 @@ json_names_for_fields=true
     }
   },
   "definitions": {
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "typeUrl": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string",
+          "format": "byte"
+        }
+      }
+    },
+    "runtimeError": {
+      "type": "object",
+      "properties": {
+        "error": {
+          "type": "string"
+        },
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    },
     "testMessage": {
       "type": "object",
       "properties": {

--- a/testdata/scripts/generate_docgen_map.txt
+++ b/testdata/scripts/generate_docgen_map.txt
@@ -65,15 +65,13 @@ type SampleService interface {
 	GetSample() Sample
 }
 -- all.md.golden --
-Sample API v1.0.0
-=================
+# Sample API v1.0.0
 
 * Host `https://openbank.com`
 
 * Base Path `/path`
 
-Gets sample
------------
+## Gets sample
 
 ```sh
 curl -X GET \

--- a/testdata/scripts/generate_docgen_only_external.txt
+++ b/testdata/scripts/generate_docgen_only_external.txt
@@ -134,15 +134,13 @@ type SampleService interface {
 	ExternalSample2(ExampleRequest) Sample
 }
 -- all.md.golden --
-Sample API v1.0.0
-=================
+# Sample API v1.0.0
 
 * Host `https://openbank.com`
 
 * Base Path `/path`
 
-Gets sample
------------
+## Gets sample
 
 ```sh
 curl -X GET \
@@ -180,8 +178,7 @@ Example:
 |--------|-------------|
 | 200    |             |
 
-POST sample
------------
+## POST sample
 
 something
 

--- a/testdata/scripts/generate_go_json_tag_postproc.txt
+++ b/testdata/scripts/generate_go_json_tag_postproc.txt
@@ -31,7 +31,7 @@ type AnExampleService interface {
 package test
 
 // Person represents a homo sapien instance.
-type Person struct {
+type DPerson struct {
 	FirstName string `pb:"1" json:"first_name"`
 	LastName string `pb:"2" json:"last_name"`
 }

--- a/testdata/scripts/generate_options.txt
+++ b/testdata/scripts/generate_options.txt
@@ -11,9 +11,9 @@ grep '@java.lang.Deprecated public  static final class Message' deprecated/com/e
 grep 'string Msg = 1 \[ctype = STRING, deprecated = true, lazy = false, jstype = JS_NORMAL, weak = false\]' deprecated/com/example/deprecated/All.java
 
 grep 'all.proto is a deprecated file' deprecated/all.pb.go
-grep 'type Status int32 // Deprecated: Do not use.' deprecated/all.pb.go
-grep 'Status_Error *Status = 2 *// Deprecated: Do not use.' deprecated/all.pb.go
-grep 'Msg .* // Deprecated: Do not use.' deprecated/all.pb.go
+grep '// Deprecated: Do not use.\ntype Status int32' deprecated/all.pb.go
+grep '// Deprecated: Do not use.\n\t*Status_Error *Status = 2' deprecated/all.pb.go
+grep '// Deprecated: Do not use.\n\t*Msg' deprecated/all.pb.go
 
 -- go.mod --
 module testdata.tld/util

--- a/testdata/scripts/generate_options_openapiv2.txt
+++ b/testdata/scripts/generate_options_openapiv2.txt
@@ -89,10 +89,6 @@ type Service interface {
     "title": "this is a title",
     "version": "version not set"
   },
-  "schemes": [
-    "http",
-    "https"
-  ],
   "consumes": [
     "application/json"
   ],
@@ -104,7 +100,7 @@ type Service interface {
       "get": {
         "summary": "Retrieves message",
         "description": "Get message",
-        "operationId": "GetMessage",
+        "operationId": "operation_id",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -115,6 +111,12 @@ type Service interface {
           "404": {
             "description": "Returned when the resource does not exist.",
             "schema": {}
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/runtimeError"
+            }
           }
         },
         "parameters": [
@@ -130,6 +132,9 @@ type Service interface {
           "tag 2"
         ],
         "deprecated": true,
+        "produces": [
+          "application/xml"
+        ],
         "security": [
           {
             "ApiKeyAuth": [
@@ -149,6 +154,39 @@ type Service interface {
     }
   },
   "definitions": {
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "type_url": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string",
+          "format": "byte"
+        }
+      }
+    },
+    "runtimeError": {
+      "type": "object",
+      "properties": {
+        "error": {
+          "type": "string"
+        },
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    },
     "testMessage": {
       "type": "object",
       "properties": {


### PR DESCRIPTION
Several fixes that made tests fail.

1. Removed dependency on gogo/protobuf, we used only 2 functions
   that are in protobuf already, and they caused random failures.

2. Change underline headers in generated markdown to hash headers

3. New protoc-gen-go fails if we give it unknown flags. This means that
   we cannot pass all the options as parameters to it, as we do now.

   What that means in practice:

   a. don't put `out` as a parameter for protoc-gen-go (and other plugins);
      I hope it doesn't break some random plugins somewhere

   b. don't put `version` in config_protoc test that does nothing, as it currently fails

   c. don't put postproc options to it

4. new swagger returns slightly different output. Changed that in tests.

This should fix all the tests.