### PR TITLE
Pin protoc-gen-go version, enum name stripping

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,16 @@ out=v1/js
 protoc=js
 ```
 
+### Global section
+
+* `import_path` - see "Converting Existing Protobuf Files"
+  
+* `strip_enum_type_names` - with this option on, enums with their type prefixed
+  will be renamed to the version without prefix.
+  
+  Note that this might produce invalid protobuf that stops compiling in 1.4.*
+  protoc-gen-go, if the enum names clash.
+
 ### Section `[protoc]`
 
 The path where to check for (or where to download) the `protoc` binary can be configured.
@@ -415,6 +425,13 @@ generate` tool:
 
 * `out` - overrides the output path of `protoc`. If not defined, output will be
   the same directory as the location of the `.gunk` files.
+
+* `plugin_version` - specify version, currently working only for protoc-gen-go,
+  as other plugins are bundled with protoc. This will clone and go build
+  protoc-gen-go in gunk cache folder.
+
+* `json_tag_postproc` - uses `json` tags defined in gunk file also for go-generated
+  file
 
 All other `name[=value]` pairs specified within the `generate` section will be
 passed as plugin parameters to `protoc` and the `protoc-gen-<type>` generators.

--- a/generate/download.go
+++ b/generate/download.go
@@ -217,3 +217,80 @@ func protocDownloadURL(os, arch, version string) (string, error) {
 		platform,
 	), nil
 }
+
+func BuildProtocGenGo(version string) (string, error) {
+	if version == "" {
+		// require version. this is used only with version explicitly set.
+		return "", fmt.Errorf("must provide protoc-gen-go version")
+	}
+
+	// Get the OS-specific cache directory.
+	cachePath, err := os.UserCacheDir()
+	if err != nil {
+		return "", err
+	}
+	if dir := os.Getenv("GUNK_CACHE_DIR"); dir != "" {
+		// Allow overriding the cache dir entirely. Mainly for
+		// the tests.
+		cachePath = dir
+	}
+
+	gitCloneDir := filepath.Join(cachePath, "gunk", fmt.Sprintf("protoc-gen-go-%s", version))
+
+	binaryDir := filepath.Join(gitCloneDir, "protoc-gen-go")
+	binaryPath := filepath.Join(binaryDir, "protoc-gen-go")
+
+	// lock cannot be in the dir where we git clone, otherwise git is unhappy
+	lockPath := gitCloneDir + ".lock"
+
+	// First, grab a lock separate from the destination file. The
+	// destination file is a binary we'll want to execute, so using it
+	// directly as the lock can lead to "text file busy" errors.
+	unlock, err := lockedfile.MutexAt(lockPath).Lock()
+	if err != nil {
+		panic(err)
+	}
+	defer unlock()
+
+	_, fErr := os.Stat(binaryPath)
+	if !os.IsNotExist(fErr) {
+		if fErr != nil {
+			return "", fErr
+		}
+
+		return binaryPath, nil
+	}
+
+	// remove the whole git clone dir if something happened wrong
+	_, fErr = os.Stat(gitCloneDir)
+	if !os.IsNotExist(fErr) {
+		if fErr != nil {
+			return "", fErr
+		}
+
+		if err := os.RemoveAll(gitCloneDir); err != nil {
+			return "", err
+		}
+	}
+
+	gitCmd := log.ExecCommand("git", "clone", "--depth", "1", "--branch", version, "https://github.com/golang/protobuf", gitCloneDir)
+	err = gitCmd.Run()
+	if err != nil {
+		all := "git clone --depth 1 --branch " + version + " https://github.com/golang/protobuf " + gitCloneDir
+		return "", log.ExecError(all, err)
+	}
+
+	buildCmd := log.ExecCommand("go", "build")
+	buildCmd.Dir = binaryDir
+
+	var stderr bytes.Buffer
+	buildCmd.Stderr = &stderr
+
+	err = buildCmd.Run()
+	if err != nil {
+		all := "go build"
+		return "", log.ExecError(all, err)
+	}
+
+	return binaryPath, nil
+}

--- a/generate/post_process.go
+++ b/generate/post_process.go
@@ -1,39 +1,13 @@
 package generate
 
 import (
-	"strconv"
-
 	"github.com/gunk/gunk/config"
 )
 
-// parsePostProcBoolParam returns true if the given parameter name exists and is a truthful value.
-func parsePostProcBoolParam(paramName string, gen config.Generator) (bool, error) {
-	for _, param := range gen.PostProcParams {
-		if param.Key == paramName {
-			result, err := strconv.ParseBool(param.Value)
-			if err != nil {
-				return false, err
-			}
-			return result, nil
-		}
-	}
-	return false, nil
-}
-
 // postProcess processes the input file before writing to output file.
 func postProcess(input []byte, gen config.Generator) ([]byte, error) {
-	const (
-		protocGenGoCmd           = "protoc-gen-go"
-		jsonTagPostprocParamName = "json_tag_postproc"
-	)
-
-	switch gen.Command {
-	case protocGenGoCmd:
-		jsonTagPostprocEnabled, err := parsePostProcBoolParam(jsonTagPostprocParamName, gen)
-		if err != nil {
-			return nil, err
-		}
-		if jsonTagPostprocEnabled {
+	if gen.IsGo() {
+		if gen.JSONPostProc {
 			return jsonTagPostProcessor(input)
 		}
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -145,7 +145,7 @@ func TestScripts(t *testing.T) {
 	p := testscript.Params{
 		Dir: filepath.Join("testdata", "scripts"),
 		Setup: func(e *testscript.Env) error {
-			e.Vars = append(e.Vars, "GOPROXY="+proxyURL)
+			e.Vars = append(e.Vars, "GOPROXY="+proxyURL+",https://proxy.golang.org,direct")
 			e.Vars = append(e.Vars, "GONOSUMDB=*")
 			e.Vars = append(e.Vars, "GUNK_CACHE_DIR="+cacheDir)
 			return nil

--- a/testdata/scripts/generate_same_const_names_striperror.txt
+++ b/testdata/scripts/generate_same_const_names_striperror.txt
@@ -1,0 +1,30 @@
+! gunk generate .
+
+stderr 'already declared'
+
+-- .gunkconfig --
+strip_enum_type_names=true
+[generate go]
+
+[protoc]
+version=v3.6.0
+
+-- go.mod --
+module testdata.tld/util
+
+-- util.gunk --
+package util
+
+type Status int
+
+const (
+	FOO Status = iota
+	BAR
+)
+
+type Available int
+
+const (
+	Available_FOO Available = iota
+	BAZ
+)

--- a/testdata/scripts/generate_strip_names.txt
+++ b/testdata/scripts/generate_strip_names.txt
@@ -1,0 +1,27 @@
+gunk generate .
+
+grep '\tAvailable_FOO Available = 0' all.pb.go
+grep '\tAvailable_BAZ Available = 1' all.pb.go
+grep '\tAvailable_BAR Available = 2' all.pb.go
+
+
+-- .gunkconfig --
+strip_enum_type_names=true
+[generate go]
+
+[protoc]
+version=v3.6.0
+
+-- go.mod --
+module testdata.tld/util
+
+-- util.gunk --
+package util
+
+type Available int
+
+const (
+	Available_FOO Available = iota
+	Available_BAZ
+	Available_BAR
+)

--- a/testdata/scripts/old_protocgo_same_const_names.txt
+++ b/testdata/scripts/old_protocgo_same_const_names.txt
@@ -1,0 +1,32 @@
+gunk generate .
+
+grep '\tAvailable_FOO Available = 0' all.pb.go
+
+-- .gunkconfig --
+strip_enum_type_names=true
+
+[protoc]
+version=v3.12.0
+
+[generate go]
+plugin_version=v1.3.4
+
+-- go.mod --
+module testdata.tld/util
+
+-- util.gunk --
+package util
+
+type Status int
+
+const (
+	FOO Status = iota
+	BAR
+)
+
+type Available int
+
+const (
+	Available_FOO Available = iota
+	BAZ
+)


### PR DESCRIPTION
Before, by default gunk removed type names from enums. Unfortunately that makes us stuck with
old version of protoc-gen-go, because new versions don't allow enum clashes.

In order to allow pinning of protoc-gen-go, we need to git-clone the protobuf repo in temp
folder and get the binary from there. But that seems to be working.

I also re-enabled the enum name stripping, but under global option.