### PR TITLE
Fix openapi schema

### DIFF
--- a/generate/generate.go
+++ b/generate/generate.go
@@ -428,7 +428,7 @@ func (g *Generator) generatePlugin(req plugin.CodeGeneratorRequest, gen configWi
 			outPath = filepath.Join(dir, *rf.Name)
 		}
 
-		if err := ioutil.WriteFile(outPath, data, 0644); err != nil {
+		if err := ioutil.WriteFile(outPath, data, 0o644); err != nil {
 			return fmt.Errorf("unable to write to file %q: %w", outPath, err)
 		}
 	}
@@ -743,6 +743,12 @@ func (g *Generator) messageOptions(tspec *ast.TypeSpec) (*desc.MessageOptions, e
 			o.NoStandardDescriptorAccessor = proto.Bool(constant.BoolVal(tag.Value))
 		case "github.com/gunk/opt/message.Deprecated":
 			o.Deprecated = proto.Bool(constant.BoolVal(tag.Value))
+		case "github.com/gunk/opt/openapiv2.Schema":
+			schema := &options.Schema{}
+			reflectutil.UnmarshalAST(schema, tag.Expr)
+			if err := proto.SetExtension(o, options.E_Openapiv2Schema, schema); err != nil {
+				return nil, err
+			}
 		default:
 			return nil, fmt.Errorf("gunk message option %q not supported", s)
 		}

--- a/testdata/scripts/generate_schema.txt
+++ b/testdata/scripts/generate_schema.txt
@@ -1,0 +1,119 @@
+gunk generate
+cmp all.swagger.json all.swagger.json.golden
+
+# note that this cannot be used with openapiv2, because
+# they have different proto option definitions that are not compatible
+# with the old one (that we currently use)
+
+-- go.mod --
+module testdata.tld/util
+
+require (
+	github.com/gunk/opt v0.0.0-20190514110406-385321f21939
+)
+-- .gunkconfig --
+[generate swagger]
+plugin_version=v1.14.4
+
+-- util.gunk --
+package util
+
+import (
+	"github.com/gunk/opt/openapiv2"
+)
+
+// +gunk openapiv2.Schema{
+//         JSONSchema: openapiv2.JSONSchema{
+//                 Required: []string{"a", "b", "c"},
+//         },
+//         Example: openapiv2.Any{Value: []byte(`{"foo":"bar"}`)},
+// }
+type Util struct {
+	// +gunk openapiv2.Schema{
+	//         JSONSchema: openapiv2.JSONSchema{
+	//                 Required: []string{"d", "e", "f"},
+	//         },
+	// }
+	Hello string `pb:"1" json:"hello"`
+}
+
+type Service interface {
+	// +gunk openapiv2.Operation{
+	//         Tags:        []string{"Util"},
+	//         Description: "Get Util",
+	//         Summary:     "Retrieves Util",
+	// }
+	GetUtil(Util) Util
+}
+
+-- all.swagger.json.golden --
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "testdata.tld/util/all.proto",
+    "version": "version not set"
+  },
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {},
+  "definitions": {
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "type_url": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string",
+          "format": "byte"
+        }
+      }
+    },
+    "runtimeError": {
+      "type": "object",
+      "properties": {
+        "error": {
+          "type": "string"
+        },
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    },
+    "utilUtil": {
+      "type": "object",
+      "example": {
+        "foo": "bar"
+      },
+      "properties": {
+        "Hello": {
+          "type": "string",
+          "required": [
+            "d",
+            "e",
+            "f"
+          ]
+        }
+      },
+      "required": [
+        "a",
+        "b",
+        "c"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Fix openapi schema option to apply to messages, in order to add
optional data, such as required fields.
Unknown if there is any code depending on the field handling of
JSONSchema, so that has not been disabled.

Taken from
https://github.com/gunk/gunk/pull/326