### PR TITLE
Use openapiv2 example in docgen requests

### DIFF
--- a/docgen/parser/model.go
+++ b/docgen/parser/model.go
@@ -88,6 +88,7 @@ type Message struct {
 	Fields         []*Field
 	NestedMessages []*Message
 	Enums          []*Enum
+	FixedExample   string
 }
 
 // Response describes a response of a service.

--- a/testdata/scripts/extract_example.txt
+++ b/testdata/scripts/extract_example.txt
@@ -1,0 +1,896 @@
+gunk generate accounts.gunk
+cmp messages.pot messages.pot.golden
+cmp all.md all.md.golden
+
+
+
+-- .gunkconfig --
+[generate]
+command=docgen
+-- accounts.gunk --
+// +gunk openapiv2.Swagger{
+//         Swagger: "2.0",
+//         Info: openapiv2.Info{
+//                 Title:       "Accounts API",
+//                 Description: "Provides CRUD operations on the accounts resource.",
+//                 Version:     "1.0.0",
+//         },
+//         Host: "openbank.com",
+//         BasePath: "/path",
+//         Schemes: []openapiv2.Scheme{
+//                 openapiv2.HTTPS,
+//         },
+//         Consumes: []string{
+//                 "application/json",
+//         },
+//         Produces: []string{
+//                 "application/json",
+//         },
+//         Responses: map[string]openapiv2.Response{
+//                 "400": openapiv2.Response{
+//                         Description: "Returned when the request body is malformatted or does not match the expected request.",
+//                 },
+//                 "401": openapiv2.Response{
+//                         Description: "Returned when the request does not contains the user's credentials.",
+//                 },
+//                 "403": openapiv2.Response{
+//                         Description: "Returned when the user does not have permission to access the resource.",
+//                 },
+//                 "500": openapiv2.Response{
+//                         Description: "Returned when an unexpected error occured on the server side.",
+//                 },
+//         },
+//         SecurityDefinitions: openapiv2.SecurityDefinitions{
+//                 Security: map[string]openapiv2.SecurityScheme{
+//                         "OAuth2": openapiv2.SecurityScheme{
+//                                 Type:             openapiv2.TYPE_OAUTH2,
+//                                 Flow:             openapiv2.FLOW_ACCESS_CODE,
+//                                 Description:      "Access to accounts resources is restricted to authenticated users. The authentication process follows the Authorization Code flow.",
+//                                 AuthorizationURL: "/v1/auth",
+//                                 TokenURL:         "/v1/token",
+//                                 Scopes: openapiv2.Scopes{
+//                                         Scope: map[string]string{
+//                                                 "read":  "Grants read access",
+//                                                 "write": "Grants write access",
+//                                         },
+//                                 },
+//                         },
+//                 },
+//         },
+// }
+package accounts
+
+import (
+	"github.com/gunk/opt/http"
+	"github.com/gunk/opt/openapiv2"
+)
+
+// Account holds all details about a bank account.
+type Account struct {
+	// AccountID is the unique identifier of an account.
+	// Should not be returned as is.
+	AccountID string `pb:"1" json:"account_id"`
+	// TODO: add comment.
+	Branch string `pb:"2" json:"branch"`
+	// TODO: add comment.
+	BranchName string `pb:"3" json:"branch_name"`
+	// Status is the status of the account.
+	Status string `pb:"4" json:"status"`
+	// TODO: add comment.
+	AccruedInterestAtMaturityDate string `pb:"5" json:"accrued_interest_at_maturity_date"`
+	// TODO: add comment.
+	AvailableCreditLimit string `pb:"8" json:"available_credit_limit"`
+	// TODO: add comment.
+	CheckingInterestRate string `pb:"9" json:"checking_interest_rate"`
+	// ContractDate is the date of the contract initialization.
+	ContractDate string `pb:"10" json:"contract_date"`
+	// CreditLimit is the allowed credit limit.
+	CreditLimit string `pb:"11" json:"credit_limit"`
+	// TODO: add comment.
+	CurrentAccruedInterest string `pb:"12" json:"current_accrued_interest"`
+	// CurrentTerm is the account validity period.
+	CurrentTerm string `pb:"14" json:"current_term"`
+	// DueDate is the loan maturity date.
+	DueDate string `pb:"15" json:"due_date"`
+	// TODO: add comment.
+	InterestRate string `pb:"16" json:"interest_rate"`
+	// MaturityDate is the maturity date, format is ISO 8601
+	MaturityDate string `pb:"19" json:"maturity_date"`
+	// TODO: add comment.
+	NextPaymentDueDate string `pb:"20" json:"next_payment_due_date"`
+	// OwnerName is the name of the account's owner.
+	OwnerName string `pb:"21" json:"owner_name"`
+	// TODO: add comment.
+	StartDate string `pb:"22" json:"start_date"`
+}
+
+// GetAccountRequest is the request envelope to get an account by its identifier.
+type GetAccountRequest struct {
+	AccountID string `pb:"1" json:"account_id"`
+}
+
+// GetAccountsRequest is the request envelope to get a list of filtered accounts.
+type GetAccountsRequest struct {
+	// NextStartingIndex is a cursor for pagination. It's an AccountID that defines
+	// the current place in the total list of Accounts.
+	NextStartingIndex string `pb:"1" json:"next_starting_index"`
+}
+
+// GetAccountsResponse wraps the list of accounts.
+type GetAccountsResponse struct {
+	// Result is a list containing up to 20 Accounts.
+	Result []Account `pb:"1" json:"result"`
+	// HasMore indicates if there are more accounts available.
+	HasMore bool `pb:"2" json:"has_more"`
+}
+
+// EntityType describes the type of the entity.
+type EntityType int
+
+const (
+	_ EntityType = iota
+	// Pers is an individual customer.
+	Pers
+	// Org is an organisation customer.
+	Org
+)
+
+// TODO: add comment.
+type AccountRole struct {
+	// TODO: add comment.
+	EntityNumber string `pb:"1" json:"entity_number"`
+	// TODO: add comment.
+	EntityType EntityType `pb:"2" json:"entity_type"`
+	// TODO: add comment.
+	Role string `pb:"3" json:"role"`
+}
+
+// TODO: add comment.
+type DebitTransaction struct {
+	// TODO: add comment.
+	Amount string `pb:"1" json:"amount"`
+	// TODO: add comment.
+	DebitAccount string `pb:"2" json:"debit_account"`
+	// TODO: add comment.
+	ExchangeRate string `pb:"3" json:"exchange_rate"`
+	// TODO: add comment.
+	IsFx bool `pb:"4" json:"is_fx"`
+}
+
+// CreateAccountRequest wraps all required fields for an account creation.
+//
+// +gunk openapiv2.Schema{
+//         Example: `{
+//             "foo": "bar"
+//         }`,
+// }
+type CreateAccountRequest struct {
+	// AccountID is the identifier of the account.
+	AccountID string `pb:"1" json:"account_id"`
+	// TODO: add comment.
+	Description string `pb:"2" json:"description"`
+	// TODO: add comment.
+	AccountRoles []AccountRole `pb:"3" json:"account_roles"`
+	// TODO: add comment.
+	Branch string `pb:"4" json:"branch"`
+	// TODO: add comment.
+	Customer string `pb:"5" json:"customer"`
+	// TODO: add comment.
+	DebitTransaction DebitTransaction `pb:"6" json:"debit_transaction"`
+	// TODO: add comment.
+	InterestRate string `pb:"7" json:"interest_rate"`
+	// TODO: add comment.
+	MaturityDate string `pb:"9" json:"maturity_date"`
+	// TODO: add comment.
+	Minor string `pb:"10" json:"minor"`
+}
+
+// CreateAccountResponse is the response envelope for an account creation.
+type CreateAccountResponse struct {
+	// AccountID is the unique identifier of the newly created account.
+	AccountID string `pb:"1" json:"account_id"`
+	// CreditTransactionNumber is the transaction number of the credited account.
+	CreditTransactionNumber string `pb:"2" json:"credit_transaction_number"`
+	// DebitTransactionNumber is the transaction number of the debited account.
+	DebitTransactionNumber string `pb:"3" json:"debit_transaction_number"`
+	// TODO: add comment.
+	Minor string `pb:"5" json:"minor"`
+}
+
+// UpdateAccountRequest wraps all fields available for update.
+type UpdateAccountRequest struct {
+	// AccountID is the unique identifier of the account to update.
+	AccountID string `pb:"1" json:"account_id"`
+	// TODO: add comment.
+	Description string `pb:"2" json:"description"`
+}
+
+// DeleteAccountRequest is the request envelope to delete an account.
+type DeleteAccountRequest struct {
+	// AccountID is the unique identifier of the account to delete.
+	AccountID string `pb:"1" json:"account_id"`
+}
+
+// AccountService provides Account operations.
+type AccountService interface {
+	// GetAccount retrieves the detail of an account, selected by its id.
+	//
+	// +gunk http.Match{
+	//         Method: "GET",
+	//         Path:   "/v1/accounts/{AccountID}",
+	// }
+	// +gunk openapiv2.Operation{
+	//         Tags:        []string{"Account"},
+	//         Description: "Retrieves all data from an account, selected by the account_id you supplied.",
+	//         Summary:     "Retrieve an account",
+	//         Responses: map[string]openapiv2.Response{
+	//                 "200": openapiv2.Response{
+	//                         Description: "Request executed successfully.",
+	//                         Schema: openapiv2.Schema{
+	//                                 JSONSchema: openapiv2.JSONSchema{
+	//                                         Ref: "#/definitions/accountsAccount",
+	//                                 },
+	//                         },
+	//                 },
+	//                 "404": openapiv2.Response{
+	//                         Description: "Returned when the resource is not found.",
+	//                 },
+	//         },
+	//         Security: []openapiv2.SecurityRequirement{
+	//                 {
+	//                         SecurityRequirement: map[string]openapiv2.SecurityRequirement_SecurityRequirementValue{
+	//                                 "OAuth2": openapiv2.SecurityRequirement_SecurityRequirementValue{
+	//                                         Scope: []string{
+	//                                                 "read",
+	//                                         },
+	//                                 },
+	//                         },
+	//                 },
+	//         },
+	// }
+	GetAccount(GetAccountRequest) Account
+
+	// GetAccounts returns a list containing up to 20 accounts.
+	//
+	// +gunk http.Match{
+	//         Method: "GET",
+	//         Path:   "/v1/accounts",
+	// }
+	// +gunk openapiv2.Operation{
+	//         Tags:        []string{"Account"},
+	//         Description: "Returns a list containing up to 20 accounts. You can paginate through account by supplying next_starting_index in your subsequents calls. next_starting_index contains the account_id of the last account_id of the current page.",
+	//         Summary:     "List all accounts",
+	//         Responses: map[string]openapiv2.Response{
+	//                 "200": openapiv2.Response{
+	//                         Description: "Request executed successfully.",
+	//                         Schema: openapiv2.Schema{
+	//                                 JSONSchema: openapiv2.JSONSchema{
+	//                                         Ref: "#/definitions/accountsGetAccountsResponse",
+	//                                 },
+	//                         },
+	//                 },
+	//         },
+	//         Security: []openapiv2.SecurityRequirement{
+	//                 {
+	//                         SecurityRequirement: map[string]openapiv2.SecurityRequirement_SecurityRequirementValue{
+	//                                 "OAuth2": openapiv2.SecurityRequirement_SecurityRequirementValue{
+	//                                         Scope: []string{
+	//                                                 "read",
+	//                                         },
+	//                                 },
+	//                         },
+	//                 },
+	//         },
+	// }
+	GetAccounts(GetAccountsRequest) GetAccountsResponse
+
+	// CreateAccount creates a new account and return its id.
+	//
+	// +gunk http.Match{
+	//         Method: "POST",
+	//         Path:   "/v1/accounts",
+	//         Body:   "*",
+	// }
+	// +gunk openapiv2.Operation{
+	//         Tags:        []string{"Account"},
+	//         Description: "Creates a new account",
+	//         Summary:     "Create an account",
+	//         Responses: map[string]openapiv2.Response{
+	//                 "201": openapiv2.Response{
+	//                         Description: "Account created successfully.",
+	//                         Schema: openapiv2.Schema{
+	//                                 JSONSchema: openapiv2.JSONSchema{
+	//                                         Ref: "#/definitions/accountsCreateAccountResponse",
+	//                                 },
+	//                         },
+	//                 },
+	//         },
+	//         Security: []openapiv2.SecurityRequirement{
+	//                 {
+	//                         SecurityRequirement: map[string]openapiv2.SecurityRequirement_SecurityRequirementValue{
+	//                                 "OAuth2": openapiv2.SecurityRequirement_SecurityRequirementValue{
+	//                                         Scope: []string{
+	//                                                 "write",
+	//                                         },
+	//                                 },
+	//                         },
+	//                 },
+	//         },
+	// }
+	CreateAccount(CreateAccountRequest) CreateAccountResponse
+
+	// UpdateAccount updates an account.
+	//
+	// +gunk http.Match{
+	//         Method: "PUT",
+	//         Path:   "/v1/accounts/{AccountID}",
+	//         Body:   "*",
+	// }
+	// +gunk openapiv2.Operation{
+	//         Tags:        []string{"Account"},
+	//         Description: "Updates an account with all the fields supplied.",
+	//         Summary:     "Update an account",
+	//         Responses: map[string]openapiv2.Response{
+	//                 "204": openapiv2.Response{
+	//                         Description: "Account updated successfully.",
+	//                 },
+	//         },
+	//         Security: []openapiv2.SecurityRequirement{
+	//                 {
+	//                         SecurityRequirement: map[string]openapiv2.SecurityRequirement_SecurityRequirementValue{
+	//                                 "OAuth2": openapiv2.SecurityRequirement_SecurityRequirementValue{
+	//                                         Scope: []string{
+	//                                                 "write",
+	//                                         },
+	//                                 },
+	//                         },
+	//                 },
+	//         },
+	// }
+	UpdateAccount(UpdateAccountRequest)
+
+	// DeleteAccount deletes an account.
+	//
+	// +gunk http.Match{
+	//         Method: "DELETE",
+	//         Path:   "/v1/accounts/{AccountID}",
+	// }
+	// +gunk openapiv2.Operation{
+	//         Tags:        []string{"Account"},
+	//         Description: "Permanently delete an account.",
+	//         Summary:     "Delete an account",
+	//         Responses: map[string]openapiv2.Response{
+	//                 "204": openapiv2.Response{
+	//                         Description: "Account deleted successfully.",
+	//                 },
+	//         },
+	//         Security: []openapiv2.SecurityRequirement{
+	//                 {
+	//                         SecurityRequirement: map[string]openapiv2.SecurityRequirement_SecurityRequirementValue{
+	//                                 "OAuth2": openapiv2.SecurityRequirement_SecurityRequirementValue{
+	//                                         Scope: []string{
+	//                                                 "write",
+	//                                         },
+	//                                 },
+	//                         },
+	//                 },
+	//         },
+	// }
+	DeleteAccount(DeleteAccountRequest)
+}
+
+-- messages.pot.golden --
+# Messages.pot - Contains all msgid extracted from swagger definitions.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid   ""
+msgstr  "Project-Id-Version: %s\n"
+		"Report-Msgid-Bugs-To: %s\n"
+		"POT-Creation-Date: %s\n"
+		"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+		"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+		"Language-Team: LANGUAGE <LL@li.org>\n"
+		"Language: \n"
+		"MIME-Version: 1.0\n"
+		"Content-Type: text/plain; charset=CHARSET\n"
+		"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Account created successfully."
+msgstr ""
+
+msgid "Account deleted successfully."
+msgstr ""
+
+msgid "Account updated successfully."
+msgstr ""
+
+msgid "AccountID is the identifier of the account."
+msgstr ""
+
+msgid "AccountID is the unique identifier of an account. Should not be returned as is."
+msgstr ""
+
+msgid "AccountID is the unique identifier of the account to delete."
+msgstr ""
+
+msgid "AccountID is the unique identifier of the account to update."
+msgstr ""
+
+msgid "AccountID is the unique identifier of the newly created account."
+msgstr ""
+
+msgid "Accounts API"
+msgstr ""
+
+msgid "Base Path"
+msgstr ""
+
+msgid "Body Parameters"
+msgstr ""
+
+msgid "ContractDate is the date of the contract initialization."
+msgstr ""
+
+msgid "Create an account"
+msgstr ""
+
+msgid "Creates a new account"
+msgstr ""
+
+msgid "CreditLimit is the allowed credit limit."
+msgstr ""
+
+msgid "CreditTransactionNumber is the transaction number of the credited account."
+msgstr ""
+
+msgid "CurrentTerm is the account validity period."
+msgstr ""
+
+msgid "DebitTransactionNumber is the transaction number of the debited account."
+msgstr ""
+
+msgid "Delete an account"
+msgstr ""
+
+msgid "DueDate is the loan maturity date."
+msgstr ""
+
+msgid "EntityType describes the type of the entity."
+msgstr ""
+
+msgid "Enums"
+msgstr ""
+
+msgid "HTTP Request"
+msgstr ""
+
+msgid "HasMore indicates if there are more accounts available."
+msgstr ""
+
+msgid "Host"
+msgstr ""
+
+msgid "List all accounts"
+msgstr ""
+
+msgid "MaturityDate is the maturity date, format is ISO 8601"
+msgstr ""
+
+msgid "Objects"
+msgstr ""
+
+msgid "Org is an organisation customer."
+msgstr ""
+
+msgid "OwnerName is the name of the account's owner."
+msgstr ""
+
+msgid "Permanently delete an account."
+msgstr ""
+
+msgid "Pers is an individual customer."
+msgstr ""
+
+msgid "Provides CRUD operations on the accounts resource."
+msgstr ""
+
+msgid "Query Parameters"
+msgstr ""
+
+msgid "Request executed successfully."
+msgstr ""
+
+msgid "Response body"
+msgstr ""
+
+msgid "Response codes"
+msgstr ""
+
+msgid "Responses"
+msgstr ""
+
+msgid "Result is a list containing up to 20 Accounts."
+msgstr ""
+
+msgid "Retrieve an account"
+msgstr ""
+
+msgid "Retrieves all data from an account, selected by the account_id you supplied."
+msgstr ""
+
+msgid "Returned when an unexpected error occured on the server side."
+msgstr ""
+
+msgid "Returned when the request body is malformatted or does not match the expected request."
+msgstr ""
+
+msgid "Returned when the request does not contains the user's credentials."
+msgstr ""
+
+msgid "Returned when the resource is not found."
+msgstr ""
+
+msgid "Returned when the user does not have permission to access the resource."
+msgstr ""
+
+msgid "Returns a list containing up to 20 accounts. You can paginate through account by supplying next_starting_index in your subsequents calls. next_starting_index contains the account_id of the last account_id of the current page."
+msgstr ""
+
+msgid "Status is the status of the account."
+msgstr ""
+
+msgid "TODO: add comment."
+msgstr ""
+
+msgid "USE_YOUR_TOKEN"
+msgstr ""
+
+msgid "Update an account"
+msgstr ""
+
+msgid "Updates an account with all the fields supplied."
+msgstr ""
+-- all.md.golden --
+# Accounts API v1.0.0
+
+Provides CRUD operations on the accounts resource.
+
+* Host `https://openbank.com`
+
+* Base Path `/path`
+
+## Create an account
+
+Creates a new account
+
+```sh
+curl -X POST \
+	https://openbank.com/path/v1/accounts \
+	-H 'Authorization: Bearer USE_YOUR_TOKEN' \
+	-d '{
+		"foo": "bar"
+	}'
+```
+
+### HTTP Request
+
+`POST https://openbank.com/path/v1/accounts`
+
+### Body Parameters
+
+| Name              | Type             | Description                                 |
+|-------------------|------------------|---------------------------------------------|
+| account_id        | string           | AccountID is the identifier of the account. |
+| description       | string           | TODO: add comment.                          |
+| account_roles     | \[]AccountRole   | TODO: add comment.                          |
+| branch            | string           | TODO: add comment.                          |
+| customer          | string           | TODO: add comment.                          |
+| debit_transaction | DebitTransaction | TODO: add comment.                          |
+| interest_rate     | string           | TODO: add comment.                          |
+| maturity_date     | string           | TODO: add comment.                          |
+| minor             | string           | TODO: add comment.                          |
+
+##### Objects
+
+###### AccountRole
+
+| Name          | Type       | Description        |
+|---------------|------------|--------------------|
+| entity_number | string     | TODO: add comment. |
+| entity_type   | EntityType | TODO: add comment. |
+| role          | string     | TODO: add comment. |
+
+###### DebitTransaction
+
+| Name          | Type   | Description        |
+|---------------|--------|--------------------|
+| amount        | string | TODO: add comment. |
+| debit_account | string | TODO: add comment. |
+| exchange_rate | string | TODO: add comment. |
+| is_fx         | bool   | TODO: add comment. |
+
+##### Enums
+
+###### EntityType
+
+EntityType describes the type of the entity.
+
+| Value | Description                      |
+|-------|----------------------------------|
+| Pers  | Pers is an individual customer.  |
+| Org   | Org is an organisation customer. |
+
+### Responses
+
+#### Response body
+
+| Name                      | Type   | Description                                                                |
+|---------------------------|--------|----------------------------------------------------------------------------|
+| account_id                | string | AccountID is the unique identifier of the newly created account.           |
+| credit_transaction_number | string | CreditTransactionNumber is the transaction number of the credited account. |
+| debit_transaction_number  | string | DebitTransactionNumber is the transaction number of the debited account.   |
+| minor                     | string | TODO: add comment.                                                         |
+
+Example:
+
+```json
+{
+  "account_id": "string",
+  "credit_transaction_number": "string",
+  "debit_transaction_number": "string",
+  "minor": "string"
+}
+```
+
+#### Response codes
+
+| Status | Description                                                                            |
+|--------|----------------------------------------------------------------------------------------|
+| 201    | Account created successfully.                                                          |
+| 400    | Returned when the request body is malformatted or does not match the expected request. |
+| 401    | Returned when the request does not contains the user's credentials.                    |
+| 403    | Returned when the user does not have permission to access the resource.                |
+| 500    | Returned when an unexpected error occured on the server side.                          |
+
+## Delete an account
+
+Permanently delete an account.
+
+```sh
+curl -X DELETE \
+	https://openbank.com/path/v1/accounts/{AccountID} \
+	-H 'Authorization: Bearer USE_YOUR_TOKEN'
+```
+
+### HTTP Request
+
+`DELETE https://openbank.com/path/v1/accounts/{AccountID}`
+
+### Query Parameters
+
+| Name       | Type   | Description                                                  |
+|------------|--------|--------------------------------------------------------------|
+| account_id | string | AccountID is the unique identifier of the account to delete. |
+
+### Responses
+
+#### Response codes
+
+| Status | Description                                                                            |
+|--------|----------------------------------------------------------------------------------------|
+| 204    | Account deleted successfully.                                                          |
+| 400    | Returned when the request body is malformatted or does not match the expected request. |
+| 401    | Returned when the request does not contains the user's credentials.                    |
+| 403    | Returned when the user does not have permission to access the resource.                |
+| 500    | Returned when an unexpected error occured on the server side.                          |
+
+## Retrieve an account
+
+Retrieves all data from an account, selected by the account_id you supplied.
+
+```sh
+curl -X GET \
+	https://openbank.com/path/v1/accounts/{AccountID} \
+	-H 'Authorization: Bearer USE_YOUR_TOKEN'
+```
+
+### HTTP Request
+
+`GET https://openbank.com/path/v1/accounts/{AccountID}`
+
+### Query Parameters
+
+| Name       | Type   | Description |
+|------------|--------|-------------|
+| account_id | string |             |
+
+### Responses
+
+#### Response body
+
+| Name                              | Type   | Description                                                                     |
+|-----------------------------------|--------|---------------------------------------------------------------------------------|
+| account_id                        | string | AccountID is the unique identifier of an account. Should not be returned as is. |
+| branch                            | string | TODO: add comment.                                                              |
+| branch_name                       | string | TODO: add comment.                                                              |
+| status                            | string | Status is the status of the account.                                            |
+| accrued_interest_at_maturity_date | string | TODO: add comment.                                                              |
+| available_credit_limit            | string | TODO: add comment.                                                              |
+| checking_interest_rate            | string | TODO: add comment.                                                              |
+| contract_date                     | string | ContractDate is the date of the contract initialization.                        |
+| credit_limit                      | string | CreditLimit is the allowed credit limit.                                        |
+| current_accrued_interest          | string | TODO: add comment.                                                              |
+| current_term                      | string | CurrentTerm is the account validity period.                                     |
+| due_date                          | string | DueDate is the loan maturity date.                                              |
+| interest_rate                     | string | TODO: add comment.                                                              |
+| maturity_date                     | string | MaturityDate is the maturity date, format is ISO 8601                           |
+| next_payment_due_date             | string | TODO: add comment.                                                              |
+| owner_name                        | string | OwnerName is the name of the account's owner.                                   |
+| start_date                        | string | TODO: add comment.                                                              |
+
+Example:
+
+```json
+{
+  "account_id": "string",
+  "branch": "string",
+  "branch_name": "string",
+  "status": "string",
+  "accrued_interest_at_maturity_date": "string",
+  "available_credit_limit": "string",
+  "checking_interest_rate": "string",
+  "contract_date": "string",
+  "credit_limit": "string",
+  "current_accrued_interest": "string",
+  "current_term": "string",
+  "due_date": "string",
+  "interest_rate": "string",
+  "maturity_date": "string",
+  "next_payment_due_date": "string",
+  "owner_name": "string",
+  "start_date": "string"
+}
+```
+
+#### Response codes
+
+| Status | Description                                                                            |
+|--------|----------------------------------------------------------------------------------------|
+| 200    | Request executed successfully.                                                         |
+| 404    | Returned when the resource is not found.                                               |
+| 400    | Returned when the request body is malformatted or does not match the expected request. |
+| 401    | Returned when the request does not contains the user's credentials.                    |
+| 403    | Returned when the user does not have permission to access the resource.                |
+| 500    | Returned when an unexpected error occured on the server side.                          |
+
+## List all accounts
+
+Returns a list containing up to 20 accounts. You can paginate through account by supplying next_starting_index in your subsequents calls. next_starting_index contains the account_id of the last account_id of the current page.
+
+```sh
+curl -X GET \
+	https://openbank.com/path/v1/accounts \
+	-H 'Authorization: Bearer USE_YOUR_TOKEN'
+```
+
+### HTTP Request
+
+`GET https://openbank.com/path/v1/accounts`
+
+### Responses
+
+#### Response body
+
+| Name     | Type       | Description                                             |
+|----------|------------|---------------------------------------------------------|
+| result   | \[]Account | Result is a list containing up to 20 Accounts.          |
+| has_more | bool       | HasMore indicates if there are more accounts available. |
+
+##### Objects
+
+###### Account
+
+| Name                              | Type   | Description                                                                     |
+|-----------------------------------|--------|---------------------------------------------------------------------------------|
+| account_id                        | string | AccountID is the unique identifier of an account. Should not be returned as is. |
+| branch                            | string | TODO: add comment.                                                              |
+| branch_name                       | string | TODO: add comment.                                                              |
+| status                            | string | Status is the status of the account.                                            |
+| accrued_interest_at_maturity_date | string | TODO: add comment.                                                              |
+| available_credit_limit            | string | TODO: add comment.                                                              |
+| checking_interest_rate            | string | TODO: add comment.                                                              |
+| contract_date                     | string | ContractDate is the date of the contract initialization.                        |
+| credit_limit                      | string | CreditLimit is the allowed credit limit.                                        |
+| current_accrued_interest          | string | TODO: add comment.                                                              |
+| current_term                      | string | CurrentTerm is the account validity period.                                     |
+| due_date                          | string | DueDate is the loan maturity date.                                              |
+| interest_rate                     | string | TODO: add comment.                                                              |
+| maturity_date                     | string | MaturityDate is the maturity date, format is ISO 8601                           |
+| next_payment_due_date             | string | TODO: add comment.                                                              |
+| owner_name                        | string | OwnerName is the name of the account's owner.                                   |
+| start_date                        | string | TODO: add comment.                                                              |
+
+Example:
+
+```json
+{
+  "result": [
+    {
+      "account_id": "string",
+      "branch": "string",
+      "branch_name": "string",
+      "status": "string",
+      "accrued_interest_at_maturity_date": "string",
+      "available_credit_limit": "string",
+      "checking_interest_rate": "string",
+      "contract_date": "string",
+      "credit_limit": "string",
+      "current_accrued_interest": "string",
+      "current_term": "string",
+      "due_date": "string",
+      "interest_rate": "string",
+      "maturity_date": "string",
+      "next_payment_due_date": "string",
+      "owner_name": "string",
+      "start_date": "string"
+    }
+  ],
+  "has_more": "bool"
+}
+```
+
+#### Response codes
+
+| Status | Description                                                                            |
+|--------|----------------------------------------------------------------------------------------|
+| 200    | Request executed successfully.                                                         |
+| 400    | Returned when the request body is malformatted or does not match the expected request. |
+| 401    | Returned when the request does not contains the user's credentials.                    |
+| 403    | Returned when the user does not have permission to access the resource.                |
+| 500    | Returned when an unexpected error occured on the server side.                          |
+
+## Update an account
+
+Updates an account with all the fields supplied.
+
+```sh
+curl -X PUT \
+	https://openbank.com/path/v1/accounts/{AccountID} \
+	-H 'Authorization: Bearer USE_YOUR_TOKEN' \
+	-d '{
+		"account_id": "string",
+		"description": "string"
+	}'
+```
+
+### HTTP Request
+
+`PUT https://openbank.com/path/v1/accounts/{AccountID}`
+
+### Query Parameters
+
+| Name       | Type   | Description                                                  |
+|------------|--------|--------------------------------------------------------------|
+| account_id | string | AccountID is the unique identifier of the account to update. |
+
+### Body Parameters
+
+| Name        | Type   | Description                                                  |
+|-------------|--------|--------------------------------------------------------------|
+| account_id  | string | AccountID is the unique identifier of the account to update. |
+| description | string | TODO: add comment.                                           |
+
+### Responses
+
+#### Response codes
+
+| Status | Description                                                                            |
+|--------|----------------------------------------------------------------------------------------|
+| 204    | Account updated successfully.                                                          |
+| 400    | Returned when the request body is malformatted or does not match the expected request. |
+| 401    | Returned when the request does not contains the user's credentials.                    |
+| 403    | Returned when the user does not have permission to access the resource.                |
+| 500    | Returned when an unexpected error occured on the server side.                          |


### PR DESCRIPTION
Use like this (also see extract_example.txt)

```
// CreateAccountRequest wraps all required fields for an account creation.
//
// +gunk openapiv2.Schema{
//         Example: `{
//             "foo": "bar"
//         }`,
// }
type CreateAccountRequest struct {
```