### PR TITLE
Validate field tags

### DIFF
--- a/loader/validate_struct_tags.go
+++ b/loader/validate_struct_tags.go
@@ -1,0 +1,86 @@
+package loader
+
+import (
+	"errors"
+	"strconv"
+	"strings"
+)
+
+// copied from go vet source code
+// https://github.com/golang/tools/blob/master/go/analysis/passes/structtag/structtag.go
+
+var (
+	errTagSyntax      = errors.New("bad syntax for struct tag pair")
+	errTagKeySyntax   = errors.New("bad syntax for struct tag key")
+	errTagValueSyntax = errors.New("bad syntax for struct tag value")
+	errTagValueSpace  = errors.New("suspicious space in struct tag value")
+	errTagSpace       = errors.New("key:\"value\" pairs not separated by spaces")
+)
+
+// validateStructTag parses the struct tag and returns an error if it is not
+// in the canonical format, which is a space-separated list of key:"value"
+// settings. The value may contain spaces.
+func validateStructTag(tag string) error {
+	// This code is based on the StructTag.Get code in package reflect.
+
+	n := 0
+	for ; tag != ""; n++ {
+		if n > 0 && tag != "" && tag[0] != ' ' {
+			// More restrictive than reflect, but catches likely mistakes
+			// like `x:"foo",y:"bar"`, which parses as `x:"foo" ,y:"bar"` with second key ",y".
+			return errTagSpace
+		}
+		// Skip leading space.
+		i := 0
+		for i < len(tag) && tag[i] == ' ' {
+			i++
+		}
+		tag = tag[i:]
+		if tag == "" {
+			break
+		}
+
+		// Scan to colon. A space, a quote or a control character is a syntax error.
+		// Strictly speaking, control chars include the range [0x7f, 0x9f], not just
+		// [0x00, 0x1f], but in practice, we ignore the multi-byte control characters
+		// as it is simpler to inspect the tag's bytes than the tag's runes.
+		i = 0
+		for i < len(tag) && tag[i] > ' ' && tag[i] != ':' && tag[i] != '"' && tag[i] != 0x7f {
+			i++
+		}
+		if i == 0 {
+			return errTagKeySyntax
+		}
+		if i+1 >= len(tag) || tag[i] != ':' {
+			return errTagSyntax
+		}
+		if tag[i+1] != '"' {
+			return errTagValueSyntax
+		}
+		tag = tag[i+1:]
+
+		// Scan quoted string to find value.
+		i = 1
+		for i < len(tag) && tag[i] != '"' {
+			if tag[i] == '\\' {
+				i++
+			}
+			i++
+		}
+		if i >= len(tag) {
+			return errTagValueSyntax
+		}
+		qvalue := tag[:i+1]
+		tag = tag[i+1:]
+
+		value, err := strconv.Unquote(qvalue)
+		if err != nil {
+			return errTagValueSyntax
+		}
+
+		if strings.IndexByte(value, ' ') >= 0 {
+			return errTagValueSpace
+		}
+	}
+	return nil
+}

--- a/testdata/scripts/generate_wrong_tag.txt
+++ b/testdata/scripts/generate_wrong_tag.txt
@@ -1,0 +1,45 @@
+! gunk generate ./message_invalid
+stderr 'message_invalid/foo.gunk:3:14: error in struct tag on InValid: bad syntax for struct tag value'
+
+! gunk generate ./message_invalid_2
+stderr 'message_invalid_2/foo.gunk:3:14: unable to convert tag to number on InValid: strconv.Atoi: parsing "gogo": invalid syntax'
+
+! gunk generate ./message_invalid_4
+stderr 'message_invalid_4/foo.gunk:3:14: error in struct tag on Second: json tag "foo" seen twice'
+
+! gunk generate ./message_invalid_5
+stderr 'message_invalid_5/foo.gunk:3:14: sequence "1" on Second has already been used in this struct'
+
+-- go.mod --
+module testdata.tld/util
+-- .gunkconfig --
+[generate go]
+-- message_invalid/foo.gunk --
+package util
+
+type Message struct {
+    InValid bool `pb:"1" json:"foo`
+}
+
+-- message_invalid_2/foo.gunk --
+package util
+
+type Message struct {
+    InValid bool `pb:"gogo"`
+}
+
+-- message_invalid_4/foo.gunk --
+package util
+
+type Message struct {
+    First bool `pb:"1" json:"foo"`
+    Second bool `pb:"2" json:"foo"`
+}
+
+-- message_invalid_5/foo.gunk --
+package util
+
+type Message struct {
+    First bool `pb:"1" json:"foo"`
+    Second bool `pb:"1" json:"bar"`
+}

--- a/testdata/scripts/loader_import_twice.txt
+++ b/testdata/scripts/loader_import_twice.txt
@@ -25,7 +25,7 @@ package package2
 import "testdata.tld/util/package1"
 
 type MyStruct struct {
-  SomeField package1.MyType `pb:"1" json:"number`
+  SomeField package1.MyType `pb:"1" json:"number"`
 }
 
 -- package2/struct2.gunk --
@@ -34,7 +34,7 @@ package package2
 import "testdata.tld/util/package1"
 
 type MyStructTwo struct {
-  SomeField package1.MyType `pb:"1" json:"number`
+  SomeField package1.MyType `pb:"1" json:"number"`
 }
 
 -- package2/all.pb.go.golden --


### PR DESCRIPTION
I have noticed gunk allows invalid (un-terminated) JSON tags,
also it allows double JSON tags and other (never used) tags.

I have copied over the go vet code to check correct tags.