### PR TITLE
Check that field tags only have pb and json; also check correctness

### DIFF
--- a/generate/generate.go
+++ b/generate/generate.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/fatih/structtag"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/options"
 	"github.com/gunk/gunk/config"
 	"github.com/gunk/gunk/generate/downloader"
@@ -811,6 +812,18 @@ func (g *Generator) convertMessage(tspec *ast.TypeSpec) (*descriptorpb.Descripto
 		if err != nil {
 			return nil, fmt.Errorf("error getting field options: %v", err)
 		}
+
+		tags, err := structtag.Parse(string(tag))
+		if err != nil {
+			return nil, fmt.Errorf("could not parse tag: %q", string(tag))
+		}
+
+		for _, t := range tags.Tags() {
+			if !(t.Key == "pb" || t.Key == "json") {
+				return nil, fmt.Errorf("other tags than json and pb are not allowed, saw %q", t.Key)
+			}
+		}
+
 		msg.Field = append(msg.Field, &descriptorpb.FieldDescriptorProto{
 			Name:     proto.String(fieldName),
 			Number:   num,

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/bmatcuk/doublestar v1.3.4
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/proto v1.9.0
+	github.com/fatih/structtag v1.2.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.5.0
 	github.com/gunk/opt v0.1.0
 	github.com/karelbilek/dirchanges v0.0.0-20210218071031-880a92f1a313

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,8 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.mod h1:hliV/p42l8fGbc6Y9bQ70uLwIvmJyVE5k4iMKlh8wCQ=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/fatih/structtag v1.2.0 h1:/OdNE99OxoI/PqaW/SuSK9uxxT3f/tcSZgon/ssNSx4=
+github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=

--- a/testdata/scripts/generate_error_moretags.txt
+++ b/testdata/scripts/generate_error_moretags.txt
@@ -1,0 +1,15 @@
+! gunk generate ./...
+stderr 'other tags than json and pb are not allowed, saw "db"'
+
+-- .gunkconfig --
+[generate]
+command=protoc-gen-go
+plugin_version=v1.26.0
+-- go.mod --
+module testdata.tld/util
+-- errors.gunk --
+package p1
+
+type Message struct {
+	Field string `pb:"1" json:"goo" db:"wrong"`
+}


### PR DESCRIPTION
In our large codebase with gunk, we have introduces some errors by either wrong
tags or by tags that are not parseable.

Add checks for that in gunk, so it does not silently ignore it.