### PR TITLE
Check that field tags only have pb and json

### DIFF
--- a/loader/validate_struct_tags.go
+++ b/loader/validate_struct_tags.go
@@ -2,12 +2,14 @@ package loader
 
 import (
 	"errors"
+	"fmt"
 	"strconv"
 	"strings"
 )
 
 // copied from go vet source code
 // https://github.com/golang/tools/blob/master/go/analysis/passes/structtag/structtag.go
+// with added check that only json and pb allowed
 
 var (
 	errTagSyntax      = errors.New("bad syntax for struct tag pair")
@@ -57,6 +59,12 @@ func validateStructTag(tag string) error {
 		if tag[i+1] != '"' {
 			return errTagValueSyntax
 		}
+
+		key := tag[:i]
+		if !(key == "pb" || key == "json") {
+			return fmt.Errorf("tag %q not allowed, only \"pb\" and \"json\"", key)
+		}
+
 		tag = tag[i+1:]
 
 		// Scan quoted string to find value.

--- a/testdata/scripts/generate_disallowed_tag.txt
+++ b/testdata/scripts/generate_disallowed_tag.txt
@@ -1,0 +1,13 @@
+! gunk generate ./message_invalid
+stderr 'message_invalid/foo.gunk:3:14: error in struct tag on InValid: tag "db" not allowed, only "pb" and "json"'
+
+-- go.mod --
+module testdata.tld/util
+-- .gunkconfig --
+[generate go]
+-- message_invalid/foo.gunk --
+package util
+
+type Message struct {
+    InValid bool `pb:"1" json:"foo" db:"wrong"`
+}


### PR DESCRIPTION
In our large codebase with gunk, we have introduces some errors by wrong tags.

Add checks for that in gunk, so it does not silently ignore it.