### PR TITLE
docgen: update auth template

### DIFF
--- a/docgen/templates/api.md
+++ b/docgen/templates/api.md
@@ -15,7 +15,7 @@
 ```sh
 curl -X {{$m.Request.Verb}} \
 	{{$.SwaggerScheme}}{{$.Swagger.Host}}{{$.Swagger.BasePath}}{{$m.Request.URI}} \
-	-H 'Authorization: Bearer {{GetText "USE_YOUR_TOKEN"}}'{{if $m.Request.Example}} \
+	-H 'x-api-key: {{GetText "USE_YOUR_API_KEY"}}'{{if $m.Request.Example}} \
 	-d '{{$m.Request.Example}}'{{end}}
 ```
 


### PR DESCRIPTION
This updates the authorization method of the docgen-generated api
documentation from Bearer token to API Key.