### PR TITLE
Separate plugin/ to a separate module,

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/proto v1.9.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.5.0
+	github.com/gunk/gunk/plugin v0.0.0
 	github.com/gunk/opt v0.1.0
 	github.com/karelbilek/dirchanges v0.0.0-20210218071031-880a92f1a313
 	github.com/kenshaw/ini v0.5.1
@@ -28,3 +29,5 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	mvdan.cc/gofumpt v0.1.1
 )
+
+replace github.com/gunk/gunk/plugin => ./plugin

--- a/plugin/go.mod
+++ b/plugin/go.mod
@@ -1,0 +1,5 @@
+module github.com/gunk/plugin
+
+go 1.16
+
+require google.golang.org/protobuf v1.27.1

--- a/plugin/go.sum
+++ b/plugin/go.sum
@@ -1,0 +1,8 @@
+github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
+github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
+github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
+google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
+google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -1,3 +1,5 @@
+// Plugin provides a helper methods to build custom protoc code generators.
+// It is used for gunk-related repos, but can be used outside of gunk.
 package plugin
 
 import (
@@ -6,7 +8,6 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/gunk/gunk/protoutil"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/pluginpb"
 )
@@ -49,7 +50,7 @@ func readRequest(r io.Reader) (*pluginpb.CodeGeneratorRequest, error) {
 }
 
 func writeResponse(w io.Writer, resp *pluginpb.CodeGeneratorResponse) error {
-	data, err := protoutil.MarshalDeterministic(resp)
+	data, err := proto.Marshal(resp)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
so it could be imported into docgen/scopegen separate repos
without introducing dependency to whole gunk.

Removed dependency from plugin to protoutil; as we don't
actually need to be deterministic there.