### PR TITLE
Replace space check for comma check

### DIFF
--- a/loader/validate_struct_tags.go
+++ b/loader/validate_struct_tags.go
@@ -15,7 +15,7 @@ var (
 	errTagSyntax      = errors.New("bad syntax for struct tag pair")
 	errTagKeySyntax   = errors.New("bad syntax for struct tag key")
 	errTagValueSyntax = errors.New("bad syntax for struct tag value")
-	errTagValueSpace  = errors.New("suspicious space in struct tag value")
+	errTagValueComma  = errors.New("JSON tags cannot use comma")
 	errTagSpace       = errors.New("key:\"value\" pairs not separated by spaces")
 )
 
@@ -86,8 +86,10 @@ func validateStructTag(tag string) error {
 			return errTagValueSyntax
 		}
 
-		if strings.IndexByte(value, ' ') >= 0 {
-			return errTagValueSpace
+		if key == "json" {
+			if strings.IndexByte(value, ',') >= 0 {
+				return errTagValueComma
+			}
 		}
 	}
 	return nil

--- a/testdata/scripts/generate_disallowed_omitempty.txt
+++ b/testdata/scripts/generate_disallowed_omitempty.txt
@@ -1,0 +1,13 @@
+! gunk generate ./message_invalid
+stderr 'message_invalid/foo.gunk:3:14: error in struct tag on InValid: JSON tags cannot use comma'
+
+-- go.mod --
+module testdata.tld/util
+-- .gunkconfig --
+[generate go]
+-- message_invalid/foo.gunk --
+package util
+
+type Message struct {
+    InValid bool `pb:"1" json:"foo,omitempty"`
+}


### PR DESCRIPTION
The go vet check includes check for space after comma, which makes sense in
go vet, as it catches `json:"foo, omitempty"`. However I simplified the code here
and include a bug, where JSON cannot have a space in name.

I have instead changed this to checking for comma, as we do not allow `json:"foo,omitempty"` anyway.