### PR TITLE
feat: Allow calling `gunk format` from stdin.

### DIFF
--- a/format/format.go
+++ b/format/format.go
@@ -8,7 +8,9 @@ import (
 	"go/parser"
 	"go/printer"
 	"go/token"
+	"io"
 	"io/ioutil"
+	"os"
 	"reflect"
 	"strconv"
 
@@ -17,6 +19,21 @@ import (
 
 // Run formats Gunk files to be canonically formatted.
 func Run(dir string, args ...string) error {
+	if len(args) == 1 && args[0] == "-" {
+		buf, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			return fmt.Errorf("error on loading: %w", err)
+		}
+		src, err := Source(buf)
+		if err != nil {
+			return fmt.Errorf("error on formatting: %w", err)
+		}
+		_, err = os.Stdout.Write(src)
+		if err != nil {
+			return fmt.Errorf("error on writing: %w", err)
+		}
+		return nil
+	}
 	fset := token.NewFileSet()
 	l := loader.Loader{Dir: dir, Fset: fset}
 	pkgs, err := l.Load(args...)


### PR DESCRIPTION
Calling `gunk format -` Will read for a single gunk source file from stdin, and then write the formatted version to stdout. This has the added benefit of being able to call it from my editor automatically via a plugin, (on save).