### PR TITLE
loader: allow package name mismatch on Go files

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -273,6 +273,9 @@ type GunkTag struct {
 // parseGunkPackage parses the package's GunkFiles, and type-checks the package
 // if l.Types is set.
 func (l *Loader) parseGunkPackage(pkg *GunkPackage) {
+	// Clear the name before parsing to avoid Go files from triggering package
+	// name mismatch
+	pkg.Name = ""
 	// parse the gunk files
 	for _, fpath := range pkg.GunkFiles {
 		file, err := parser.ParseFile(l.Fset, fpath, nil, parser.ParseComments)

--- a/testdata/scripts/generate_name_conflict.txt
+++ b/testdata/scripts/generate_name_conflict.txt
@@ -1,0 +1,23 @@
+gunk generate ./stale_generated
+exists 'stale_generated/all.pb.go'
+! gunk generate ./conflicting_package_name
+! exists 'conflicting_package_name/all.pb.go'
+
+-- .gunkconfig --
+[generate go]
+plugin_version=v1.26.0
+
+-- stale_generated/all.go --
+package stale_package_name
+
+-- stale_generated/foo.gunk --
+package diff // Different package name
+type Foo struct {
+	Bar int `pb:"1" json:"bar"`
+}
+
+-- conflicting_package_name/foo.gunk --
+package a
+
+-- conflicting_package_name/bar.gunk --
+package b


### PR DESCRIPTION
This allows compilation to succeed even if the Gunk package name has changed if the generated files are in the same directory.