### PR TITLE
WIP: loader: Handle package-loading errors

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -150,7 +150,7 @@ func Load(dir string) (*Config, error) {
 	}
 	// If no configs were found, return an error.
 	if len(cfgs) == 0 {
-		return nil, fmt.Errorf("no .gunkconfig found")
+		return nil, fmt.Errorf("no .gunkconfig found for %q", dir)
 	}
 	// Merge the found configs.
 	config := cfgs[0]

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -1,7 +1,6 @@
 package loader
 
 import (
-	"errors"
 	"fmt"
 	"go/ast"
 	"go/constant"
@@ -114,9 +113,6 @@ func (l *Loader) Load(patterns ...string) ([]*GunkPackage, error) {
 	if len(patterns) == 1 {
 		pkgPath := patterns[0]
 		if pkg := l.cache[pkgPath]; pkg != nil {
-			if len(pkg.Errors) > 0 {
-				return nil, fmt.Errorf("error loading package %q", pkgPath)
-			}
 			return []*GunkPackage{pkg}, nil
 		}
 	}
@@ -170,10 +166,6 @@ func (l *Loader) Load(patterns ...string) ([]*GunkPackage, error) {
 			l.cache = make(map[string]*GunkPackage)
 		}
 		l.cache[pkg.PkgPath] = pkg
-	}
-	if PrintErrors(pkgs) > 0 {
-		// FIXME: Return a more specific error message.
-		return nil, errors.New("error loading package")
 	}
 	return pkgs, nil
 }
@@ -239,6 +231,9 @@ func (l *Loader) Import(path string) (*types.Package, error) {
 	}
 	if len(pkgs) != 1 {
 		panic("expected Loader.Load to return exactly one package")
+	}
+	if PrintErrors(pkgs) > 0 {
+		return nil, fmt.Errorf("error importing package %q", path)
 	}
 	if pkgs[0].Types == nil {
 		panic("expected packages to have non-nil Types")

--- a/testdata/scripts/config_projectroot.txt
+++ b/testdata/scripts/config_projectroot.txt
@@ -12,7 +12,7 @@ exists gitfile/all.pb.go
 # The parent module can't see packages inside the child module, so cd into it.
 # Go 1.13 and later errors directly; hence the second error match.
 ! gunk generate ./gomod
-stderr 'no Gunk packages to generate|directory gomod is outside main module'
+stderr 'no Gunk packages to generate|directory gomod is outside main module|does not contain package'
 
 cd gomod
 gunk generate .


### PR DESCRIPTION
Currently packages are just being dropped when they error because the Errors field is not being checked.
This causes problems when packages that are imported fail to compile.

This PR fixes it by printing the error out and reporting to the caller.