### PR TITLE
lint: Add initialisms support for JSON linter

### DIFF
--- a/lint/json.go
+++ b/lint/json.go
@@ -11,6 +11,12 @@ import (
 
 func lintJSON(l *Linter, pkgs []*loader.GunkPackage) {
 	for _, pkg := range pkgs {
+		s := snaker.NewDefaultInitialisms()
+		err := s.Add(l.cfg[pkg.ID].Format.Initialisms...)
+		if err != nil {
+			l.addError(pkg.GunkSyntax[0], "error loading initialisms: %v", err)
+		}
+
 		for _, f := range pkg.GunkSyntax {
 			ast.Inspect(f, func(n ast.Node) bool {
 				switch v := n.(type) {
@@ -39,7 +45,7 @@ func lintJSON(l *Linter, pkgs []*loader.GunkPackage) {
 						l.addError(n, "expected exactly 1 name, got %d", len(v.Names))
 						return false
 					}
-					snakeCase := snaker.CamelToSnakeIdentifier(v.Names[0].Name)
+					snakeCase := s.CamelToSnakeIdentifier(v.Names[0].Name)
 					if json != snakeCase {
 						l.addError(n, "JSON name must be snake case of field name")
 						return false

--- a/lint/lint.go
+++ b/lint/lint.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/gunk/gunk/config"
 	"github.com/gunk/gunk/loader"
 )
 
@@ -76,6 +77,14 @@ func Run(dir string, enable string, disable string, args ...string) error {
 			delete(lintersToRun, name)
 		}
 	}
+	// Load package configs
+	for _, pkg := range pkgs {
+		cfg, err := config.Load(pkg.Dir)
+		if err != nil {
+			return fmt.Errorf("error loading config for %s: %w", dir, err)
+		}
+		l.cfg[pkg.ID] = cfg
+	}
 	// Run the linters
 	for _, v := range lintersToRun {
 		v.Run(l, pkgs)
@@ -90,6 +99,8 @@ func Run(dir string, enable string, disable string, args ...string) error {
 type Linter struct {
 	*loader.Loader
 	Err scanner.ErrorList
+
+	cfg map[string]*config.Config
 }
 
 // New creates a new initialized linter instance.
@@ -101,6 +112,7 @@ func New(dir string) *Linter {
 			Types: true,
 		},
 		Err: make(scanner.ErrorList, 0),
+		cfg: make(map[string]*config.Config),
 	}
 }
 

--- a/testdata/scripts/lint_json.txt
+++ b/testdata/scripts/lint_json.txt
@@ -1,6 +1,7 @@
 ! gunk lint --enable json ./no-json/
 ! gunk lint --enable json ./not-snakecase/
 gunk lint --enable json ./correct/
+gunk lint --enable json ./initialisms/
 
 -- .gunkconfig --
 [generate go]
@@ -25,4 +26,15 @@ package test
 type Foo struct {
 	BarQuz int `pb:"1" json:"bar_quz"`
 	FlippedOrder int `json:"flipped_order" pb:"2"`
+}
+
+-- initialisms/.gunkconfig --
+[format]
+initialisms=foobar
+
+-- initialisms/test.gunk --
+package test
+
+type Foo struct {
+	BazFOOBARTest int `pb:"1" json:"baz_foobar_test"`
 }


### PR DESCRIPTION
This allows the JSON linter to be consistent with the formatter.