### PR TITLE
generate: Filter path parameters

### DIFF
--- a/generate/doc/doc.go
+++ b/generate/doc/doc.go
@@ -72,7 +72,7 @@ func Generate(pkg *loader.GunkPackage, genCfg config.Generator) (p *Package, err
 	}
 	// cleanup
 	for k, v := range doc.types {
-		o, ok := v.(*Object)
+		m, ok := v.(*Message)
 		if !ok {
 			continue
 		}
@@ -80,14 +80,14 @@ func Generate(pkg *loader.GunkPackage, genCfg config.Generator) (p *Package, err
 			// Remove data types that are only part of a service.
 			delete(doc.types, k)
 		}
-		// replace ref types with the object itself
+		// replace ref types with the message itself
 		for _, s := range doc.inService[k] {
 			// replace request type
 			if req, ok := s.Request.(*Ref); ok && req.Name == k {
-				s.Request = o
+				s.Request = m
 				// fixup body field name
 				if s.BodyField != "" && s.BodyField != "*" {
-					for _, f := range o.Fields {
+					for _, f := range m.Fields {
 						if f.GunkName == s.BodyField {
 							s.BodyField = f.Name
 							break
@@ -95,11 +95,11 @@ func Generate(pkg *loader.GunkPackage, genCfg config.Generator) (p *Package, err
 					}
 				}
 				// fix path field names
-				s.Path = processPath(o, s.Path)
+				s.Path = processPath(m, s.Path)
 			}
 			// replace response type
 			if res, ok := s.Response.(*Ref); ok && res.Name == k {
-				s.Response = o
+				s.Response = m
 			}
 		}
 	}
@@ -145,7 +145,7 @@ func (doc *Doc) addType(n *ast.TypeSpec) error {
 }
 
 func (doc *Doc) addMessage(n *ast.TypeSpec, st *ast.StructType) error {
-	obj := &Object{
+	msg := &Message{
 		Name:        n.Name.Name,
 		Description: cleanDescription(n.Name.Name, n.Doc.Text()),
 	}
@@ -172,7 +172,7 @@ func (doc *Doc) addMessage(n *ast.TypeSpec, st *ast.StructType) error {
 		if json == "" {
 			json = snaker.DefaultInitialisms.CamelToSnake(name)
 		}
-		obj.Fields = append(obj.Fields, &Field{
+		msg.Fields = append(msg.Fields, &Field{
 			Name:        json,
 			GunkName:    name,
 			Description: cleanDescription(name, field.Doc.Text()),
@@ -180,7 +180,7 @@ func (doc *Doc) addMessage(n *ast.TypeSpec, st *ast.StructType) error {
 		})
 	}
 	qName := doc.qualifiedTypeName(n.Name.Name, doc.pkg.Types)
-	doc.types[qName] = obj
+	doc.types[qName] = msg
 	return nil
 }
 
@@ -232,11 +232,11 @@ func (doc *Doc) addService(n *ast.TypeSpec, ifc *ast.InterfaceType) error {
 }
 
 // processPath processes the provided path by mapping the names in the path to
-// their JSON names based on the provided Object.
-func processPath(o *Object, val string) string {
+// their JSON names based on the provided Message.
+func processPath(m *Message, val string) string {
 	formatted := ""
 	jsonName := make(map[string]string)
-	for _, f := range o.Fields {
+	for _, f := range m.Fields {
 		jsonName[f.GunkName] = f.Name
 	}
 	for {

--- a/generate/doc/json.go
+++ b/generate/doc/json.go
@@ -67,8 +67,8 @@ type Type interface {
 	typ() string
 }
 
-// Object is the documentation for an object.
-type Object struct {
+// Message is the documentation for a message.
+type Message struct {
 	// Name is the name of the data type.
 	Name string `json:"name"`
 	// Description is the description of the data type.
@@ -77,7 +77,7 @@ type Object struct {
 	Fields []*Field `json:"fields"`
 }
 
-// Field is the documentation for a field in an object.
+// Field is the documentation for a field in a message.
 type Field struct {
 	// Name is the name of the field.
 	Name string `json:"name"`
@@ -106,7 +106,7 @@ type EnumVal struct {
 	Description string `json:"description"`
 }
 
-// Ref is a reference to an Object or Enum type.
+// Ref is a reference to a Message or Enum type.
 type Ref struct {
 	// Name is the fully qualified name of the referenced type.
 	Name string `json:"name"`
@@ -134,21 +134,21 @@ type Basic struct {
 	Example string `json:"example"`
 }
 
-func (*Object) typ() string { return "object" }
-func (*Enum) typ() string   { return "enum" }
-func (*Ref) typ() string    { return "ref" }
-func (*Map) typ() string    { return "map" }
-func (*Array) typ() string  { return "array" }
-func (*Basic) typ() string  { return "basic" }
+func (*Message) typ() string { return "message" }
+func (*Enum) typ() string    { return "enum" }
+func (*Ref) typ() string     { return "ref" }
+func (*Map) typ() string     { return "map" }
+func (*Array) typ() string   { return "array" }
+func (*Basic) typ() string   { return "basic" }
 
-// MarshalJSON marshals the object to JSON with a type field.
-func (o *Object) MarshalJSON() ([]byte, error) {
+// MarshalJSON marshals the message to JSON with a type field.
+func (m *Message) MarshalJSON() ([]byte, error) {
 	return json.Marshal(struct {
 		Type string `json:"type"`
-		Object
+		Message
 	}{
-		Type:   "object",
-		Object: *o,
+		Type:    "message",
+		Message: *m,
 	})
 }
 


### PR DESCRIPTION
Only JSON names are exposed in the generated JSON. Therefore, this
commit filters the names in the path to their JSON names before passing
it to the frontend.
This allows the frontend to distinguish between path parameters and
query parameters.