### PR TITLE
feat (generate): Add capability to output as Typescript ES Module

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,7 +342,8 @@ Gunk uses a top-level `.gunkconfig` configuration file for managing the Gunk
 protocol definitons for a project:
 
 ```ini
-# Example .gunkconfig for Go, grpc-gateway, Python and JS
+# Example .gunkconfig for Go, grpc-gateway, Python and JS, TypeScript (CommonJS), TypeScript
+
 [generate go]
 out=v1/go
 plugins=grpc
@@ -359,6 +360,15 @@ out=v1/python
 out=v1/js
 import_style=commonjs
 binary
+
+[generate ts]
+service=true
+plugin_version=v0.12.0
+fix_paths_post_proc=true
+
+[generate ts_proto]
+service=true
+plugin_version=v1.110.4
 ```
 
 ### Project Search Path

--- a/generate/downloader/download.go
+++ b/generate/downloader/download.go
@@ -71,7 +71,10 @@ var ds = []Downloader{
 	Swift{},
 	GrpcSwift{},
 	GrpcPython{},
-	Ts{},
+	//use npm ts-protoc-gen package
+	Ts{ID: "ts", ModuleName: "ts-protoc-gen", BinaryName : "protoc-gen-ts"},
+	//use npm ts-proto package
+	Ts{ID: "ts_proto", ModuleName: "ts-proto", BinaryName : "protoc-gen-ts_proto"},
 	GrpcGo{},
 }
 

--- a/generate/downloader/ts.go
+++ b/generate/downloader/ts.go
@@ -12,10 +12,14 @@ import (
 	"github.com/gunk/gunk/log"
 )
 
-type Ts struct{}
+type Ts struct{
+	ID string;
+	ModuleName string;
+	BinaryName string;
+}
 
 func (g Ts) Name() string {
-	return "ts"
+	return g.ID
 }
 
 func (g Ts) Download(version string, p Paths) (string, error) {
@@ -33,11 +37,11 @@ func (g Ts) Download(version string, p Paths) (string, error) {
 		all := "npm init -y"
 		return "", log.ExecError(all, err)
 	}
-	npmCmd = log.ExecCommand("npm", "install", "ts-protoc-gen@"+version)
+	npmCmd = log.ExecCommand("npm", "install", g.ModuleName + "@" + version)
 	npmCmd.Dir = p.buildDir
 	err = npmCmd.Run()
 	if err != nil {
-		all := "npm install ts-protoc-gen@" + version
+		all := "npm install " + g.ModuleName + "@" + version
 		return "", log.ExecError(all, err)
 	}
 	// in order to be reproducible, install the *minimal* versions of everything
@@ -45,14 +49,14 @@ func (g Ts) Download(version string, p Paths) (string, error) {
 	type packageJSON struct {
 		Dependencies map[string]string `json:"dependencies"`
 	}
-	protocJSONBytes, err := ioutil.ReadFile(filepath.Join(p.buildDir, "node_modules", "ts-protoc-gen", "package.json"))
+	protocJSONBytes, err := ioutil.ReadFile(filepath.Join(p.buildDir, "node_modules", g.ModuleName, "package.json"))
 	if err != nil {
-		return "", fmt.Errorf("cannot read ts-protoc-gen package.json: %w", err)
+		return "", fmt.Errorf("cannot read " + g.ModuleName + " package.json: %w", err)
 	}
 	var protocJSON packageJSON
 	err = json.Unmarshal(protocJSONBytes, &protocJSON)
 	if err != nil {
-		return "", fmt.Errorf("cannot parse ts-protoc-gen package.json: %w", err)
+		return "", fmt.Errorf("cannot parse " + g.ModuleName + " package.json: %w", err)
 	}
 	for k, v := range protocJSON.Dependencies {
 		if strings.HasPrefix(v, "^") {
@@ -66,6 +70,6 @@ func (g Ts) Download(version string, p Paths) (string, error) {
 			}
 		}
 	}
-	binaryPath := filepath.Join(p.buildDir, "node_modules", ".bin", "protoc-gen-ts")
+	binaryPath := filepath.Join(p.buildDir, "node_modules", ".bin", g.BinaryName)
 	return binaryPath, nil
 }


### PR DESCRIPTION
This is to make it possible to generate protobuf in pure
Typescript file which can be used as ES Module like when using
with [Vite](https://vitejs.org).

Issue #365 