### PR TITLE
feat: add capability to generate TypeScript using protoc-gen-ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,12 +362,21 @@ binary
 [generate ts]
 service=true
 plugin_version=v0.12.0
-fix_paths_post_proc=true
+fix_paths_postproc=true
 
 [generate ts_proto]
 service=true
 plugin_version=v1.110.4
+
+
+[generate protoc-gen-ts]
+service=true
+plugin_version=v0.8.6-rc1
 ```
+
+- `[generate ts]` uses [ts-protoc-gen](https://www.npmjs.com/package/ts-protoc-gen)
+- `[generate ts_proto]` uses [ts-proto](https://www.npmjs.com/package/ts-proto)
+- `[generate protoc-gen-ts]` uses [protoc-gen-ts](https://www.npmjs.com/package/protoc-gen-ts)
 
 ### Project Search Path
 

--- a/generate/downloader/download.go
+++ b/generate/downloader/download.go
@@ -72,9 +72,11 @@ var ds = []Downloader{
 	GrpcSwift{},
 	GrpcPython{},
 	//use npm ts-protoc-gen package
-	Ts{ID: "ts", ModuleName: "ts-protoc-gen", BinaryName : "protoc-gen-ts"},
+	Ts{ID: "ts", ModuleName: "ts-protoc-gen", BinaryName: "protoc-gen-ts"},
 	//use npm ts-proto package
-	Ts{ID: "ts_proto", ModuleName: "ts-proto", BinaryName : "protoc-gen-ts_proto"},
+	Ts{ID: "ts_proto", ModuleName: "ts-proto", BinaryName: "protoc-gen-ts_proto"},
+	//use npm protoc-gen-ts package
+	Ts{ID: "protoc-gen-ts", ModuleName: "protoc-gen-ts", BinaryName: "protoc-gen-ts"},
 	GrpcGo{},
 }
 


### PR DESCRIPTION
This commit adds capability to generate ESM TypeScript code using protoc-gen-ts NPM package and also edit readme file to explain different types of TypeScript generators and fix minor typo error.